### PR TITLE
disk-smart: exclude zfs-volumes

### DIFF
--- a/check-plugins/disk-smart/disk-smart2
+++ b/check-plugins/disk-smart/disk-smart2
@@ -46,7 +46,7 @@ DESCRIPTION = '''This check is some kind of user interface for smartctl, which i
 DEFAULT_IGNORE = []
 
 # exclude some block devices with their numbers according to `/proc/devices`
-CMD_LIST_DISKS = "lsblk --nodeps --output name,type --noheadings --exclude 9,11,252,253,254"
+CMD_LIST_DISKS = "lsblk --nodeps --output name,type --noheadings --exclude 9,11,230,252,253,254"
 CMD_SMARTCTL = 'smartctl --xall {disk_path}'
 
 

--- a/check-plugins/disk-smart/disk-smart3
+++ b/check-plugins/disk-smart/disk-smart3
@@ -48,7 +48,7 @@ DESCRIPTION = '''This check is some kind of user interface for smartctl, which i
 DEFAULT_IGNORE = []
 
 # exclude some block devices with their numbers according to `/proc/devices`
-CMD_LIST_DISKS = "lsblk --nodeps --output name,type --noheadings --exclude 9,11,252,253,254"
+CMD_LIST_DISKS = "lsblk --nodeps --output name,type --noheadings --exclude 9,11,230,252,253,254"
 CMD_SMARTCTL = 'smartctl --xall {disk_path}'
 
 


### PR DESCRIPTION
zfs-volumes cannot be monitored by smartctl and should be excluded