### PR TITLE
Performance data aggregation on file_age check

### DIFF
--- a/check-plugins/file-age/README.rst
+++ b/check-plugins/file-age/README.rst
@@ -30,7 +30,8 @@ Help
     usage: file-age [-h] [-V] [--always-ok] [-c CRIT]
                     [--critical-count CRIT_COUNT] [--filename FILENAME]
                     [--only-dirs] [--only-files] [--password PASSWORD]
-                    [--pattern PATTERN] [--timeout TIMEOUT] [-u URL]
+                    [--pattern PATTERN] [--perfdata-mode PERFDATA_MODE]
+                    [--timeout TIMEOUT] [-u URL]
                     [--username USERNAME] [-w WARN] [--warning-count WARN_COUNT]
 
     Checks the time of last data modification for a file or directory, in seconds.
@@ -58,6 +59,9 @@ Help
                             a wildcard for multiple chars and '?' as a wildcard
                             for a single char. Does not support regex patterns.
                             Default: *.
+      --perfdata-mode       Set the performance data aggregation mode.
+                            Valid modes: ['mean', 'median']. It is disabled by
+                            default.
       --timeout TIMEOUT     Network timeout in seconds. Default: 3 (seconds)
       -u URL, --url URL     SMB: Set the url of the file (or directory) to check,
                             starting with "smb://". This is mutually exclusive
@@ -132,7 +136,9 @@ States
 Perfdata / Metrics
 ------------------
 
-There is no perfdata.
+There is perfdata. The --perfdata-mode decides which aggregation mode is going to be used.
+This check currently supports the mean, also known as average, and median aggregation.
+The check won't return any performance data for empty directories (even with the flag being set).
 
 
 Credits, License

--- a/check-plugins/file-age/file-age3
+++ b/check-plugins/file-age/file-age3
@@ -45,7 +45,7 @@ except ImportError as e:
 
 
 __author__ = 'Linuxfabrik GmbH, Zurich/Switzerland'
-__version__ = '2022031101'
+__version__ = '2022031401'
 
 DESCRIPTION = 'Checks the time of last data modification for a file or directory, in seconds.'
 
@@ -57,9 +57,6 @@ DEFAULT_WARN_COUNT = 0
 DEFAULT_PATTERN = '*'
 DEFAULT_TIMEOUT = 3
 DEFAULT_PERFDATA_MODE = None
-
-
-PERFDATA_SUPPORTED_MODES = ['mean', 'median']
 
 
 def parse_args():
@@ -132,10 +129,14 @@ def parse_args():
 
     parser.add_argument(
         '--perfdata-mode',
-        help='Set the performance data aggregation mode. Valid modes: "{}". It is disabled by default.'.format(PERFDATA_SUPPORTED_MODES),
+        help='Set the performance data aggregation mode. Default: %(default)s.',
         dest='PERFDATA_MODE',
-        type=str,
-        default=DEFAULT_PERFDATA_MODE
+        default=DEFAULT_PERFDATA_MODE,
+        choices=[
+            'mean',
+            'median',
+            'None',
+        ],
     )
 
     parser.add_argument(
@@ -195,8 +196,6 @@ def main():
         proto, url = split_url
         if proto != 'smb':
             lib.base3.oao('The protocol "{}" is not supported.'.format(proto), STATE_UNKNOWN)
-    if args.PERFDATA_MODE and args.PERFDATA_MODE not in PERFDATA_SUPPORTED_MODES:
-        lib.base3.oao('Invalid performance data aggregation mode specified: "{}". Please use one of the following modes: "{}".'.format(args.PERFDATA_MODE, PERFDATA_SUPPORTED_MODES))
 
     msg = ''
     file_count = 0

--- a/check-plugins/file-age/file-age3
+++ b/check-plugins/file-age/file-age3
@@ -45,7 +45,7 @@ except ImportError as e:
 
 
 __author__ = 'Linuxfabrik GmbH, Zurich/Switzerland'
-__version__ = '2022021601'
+__version__ = '2022031101'
 
 DESCRIPTION = 'Checks the time of last data modification for a file or directory, in seconds.'
 
@@ -56,6 +56,10 @@ DEFAULT_CRIT_COUNT = 0
 DEFAULT_WARN_COUNT = 0
 DEFAULT_PATTERN = '*'
 DEFAULT_TIMEOUT = 3
+DEFAULT_PERFDATA_MODE = None
+
+
+PERFDATA_SUPPORTED_MODES = ['mean', 'median']
 
 
 def parse_args():
@@ -127,6 +131,14 @@ def parse_args():
     )
 
     parser.add_argument(
+        '--perfdata-mode',
+        help='Set the performance data aggregation mode. Valid modes: "{}". It is disabled by default.'.format(PERFDATA_SUPPORTED_MODES),
+        dest='PERFDATA_MODE',
+        type=str,
+        default=DEFAULT_PERFDATA_MODE
+    )
+
+    parser.add_argument(
         '--timeout',
         help='Network timeout in seconds. Default: %(default)s (seconds)',
         dest='TIMEOUT',
@@ -183,11 +195,14 @@ def main():
         proto, url = split_url
         if proto != 'smb':
             lib.base3.oao('The protocol "{}" is not supported.'.format(proto), STATE_UNKNOWN)
+    if args.PERFDATA_MODE and args.PERFDATA_MODE not in PERFDATA_SUPPORTED_MODES:
+        lib.base3.oao('Invalid performance data aggregation mode specified: "{}". Please use one of the following modes: "{}".'.format(args.PERFDATA_MODE, PERFDATA_SUPPORTED_MODES))
 
     msg = ''
     file_count = 0
     crit_count = 0
     warn_count = 0
+    ages = []
 
     if args.FILENAME:
         path = Path(args.FILENAME)
@@ -198,6 +213,7 @@ def main():
                 continue
 
             age = (lib.time3.now() - item.stat().st_mtime)
+            ages.append(age)
             item_state = STATE_OK
             # not using elif, as the item could contribute to both the warn_count and crit_count
             if not lib.base3.coe(lib.base3.match_range(age, args.WARN)):
@@ -219,6 +235,7 @@ def main():
                     continue
 
                 age = (lib.time3.now() - item.stat().st_mtime)
+                ages.append(age)
                 item_state = STATE_OK
                 # not using elif, as the item could contribute to both the warn_count and crit_count
                 if not lib.base3.coe(lib.base3.match_range(age, args.WARN)):
@@ -270,8 +287,24 @@ def main():
             lib.txt3.pluralize("item", file_count),
         ) + msg
 
+    # calc perfdata if requested
+    perfdata = ''
+    if args.PERFDATA_MODE == 'mean' and len(ages) > 0:
+        perfdata += lib.base3.get_perfdata(label='Mean: Ages', value=round(float(sum(ages) / len(ages)), 3), uom='s', crit=args.CRIT, warn=args.WARN, _min=0, _max=None)
+    elif args.PERFDATA_MODE == 'median' and len(ages) > 0:
+        ages_sorted = sorted(ages)
+        middle_index = int(len(ages_sorted) / 2)
+        # differentiate even / uneven list
+        if len(ages_sorted) % 2 == 0:
+            # even
+            median = float((ages_sorted[middle_index] + ages_sorted[middle_index - 1]) / 2)
+        else:
+            # uneven (manually "flooring" it up)
+            median = float(ages_sorted[int(middle_index + 0.5)])
+        perfdata += lib.base3.get_perfdata(label='Median: Ages', value=round(median, 3), uom='s', crit=args.CRIT, warn=args.WARN, _min=0, _max=None)
+
     # over and out
-    lib.base3.oao(msg, state, always_ok=args.ALWAYS_OK)
+    lib.base3.oao(msg, state, perfdata=perfdata, always_ok=args.ALWAYS_OK)
 
 
 if __name__ == '__main__':

--- a/check-plugins/file-age/test3
+++ b/check-plugins/file-age/test3
@@ -16,7 +16,6 @@ import lib.shell3
 
 import unittest
 import tempfile
-import datetime
 
 class TestCheck(unittest.TestCase):
 
@@ -238,62 +237,44 @@ class TestCheck(unittest.TestCase):
 
     def test_scenario3_perfdata(self):
         tmpdir = tempfile.mkdtemp()
-        date_now = datetime.datetime.now()
         bash = f'''
-        touch -d '{date_now - datetime.timedelta(0, 10)}' {tmpdir}/file1
-        touch -d '{date_now - datetime.timedelta(0, 25)}' {tmpdir}/file2
-        touch -d '{date_now - datetime.timedelta(0, 100)}' {tmpdir}/file3
+        touch -d '10 seconds ago' {tmpdir}/file1
+        touch -d '25 seconds ago' {tmpdir}/file2
+        touch -d '100 seconds ago' {tmpdir}/file3
         '''
         lib.base3.coe(lib.shell3.shell_exec('bash', stdin=bash.encode()))
 
-        # the multiple if's serve as a super ugly workaround since assertTrue doesn't support multiple conditions that
-        # are OR-ed against each other and there are some precision problems with touch and certain file systems
+        # the output is being checked against a range as there's some time derivation from touch caused by certain file systems
 
         # check mean uneven
         cmd = f"./file-age3 --filename '{tmpdir}/*' --warning '15:' --warning-count '3:' --critical '20:' --critical-count '2:' --perfdata-mode=mean"
         stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(cmd))
-        is_valid = False
-        if "Mean: Ages'=44." in stdout:
-            is_valid = True
-        if "Mean: Ages'=45." in stdout:
-            is_valid = True
-        self.assertTrue(is_valid)
+        age = float(stdout.rpartition('|')[2].rpartition('=')[2].split('s')[0])  # extract age from perfdata string
+        self.assertTrue(43.0 < age < 46.0)
 
         # check median uneven
         cmd = f"./file-age3 --filename '{tmpdir}/*' --warning '15:' --warning-count '3:' --critical '20:' --critical-count '2:' --perfdata-mode=median"
         stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(cmd))
-        is_valid = False
-        if "Median: Ages'=24." in stdout:
-            is_valid = True
-        if "Median: Ages'=25." in stdout:
-            is_valid = True
-        self.assertTrue(is_valid)
+        age = float(stdout.rpartition('|')[2].rpartition('=')[2].split('s')[0])  # extract age from perfdata string
+        self.assertTrue(23.0 < age < 26.0)
 
         # add one file to make it an even file list
         bash = f'''
-        touch -d '{date_now - datetime.timedelta(0, 200)}' {tmpdir}/file4
+        touch -d '200 seconds ago' {tmpdir}/file4
         '''
         lib.base3.coe(lib.shell3.shell_exec('bash', stdin=bash.encode()))
 
         # check mean even
         cmd = f"./file-age3 --filename '{tmpdir}/*' --warning '15:' --warning-count '3:' --critical '20:' --critical-count '2:' --perfdata-mode=mean"
         stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(cmd))
-        is_valid = False
-        if "Mean: Ages'=83." in stdout:
-            is_valid = True
-        if "Mean: Ages'=82." in stdout:
-            is_valid = True
-        self.assertTrue(is_valid)
+        age = float(stdout.rpartition('|')[2].rpartition('=')[2].split('s')[0])  # extract age from perfdata string
+        self.assertTrue(81.0 < age < 84.0)
 
         # check median even
         cmd = f"./file-age3 --filename '{tmpdir}/*' --warning '15:' --warning-count '3:' --critical '20:' --critical-count '2:' --perfdata-mode=median"
         stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(cmd))
-        is_valid = False
-        if "Median: Ages'=62." in stdout:
-            is_valid = True
-        if "Median: Ages'=61." in stdout:
-            is_valid = True
-        self.assertTrue(is_valid)
+        age = float(stdout.rpartition('|')[2].rpartition('=')[2].split('s')[0])  # extract age from perfdata string
+        self.assertTrue(60.0 < age < 63.0)
 
 
 if __name__ == '__main__':

--- a/check-plugins/file-age/test3
+++ b/check-plugins/file-age/test3
@@ -16,6 +16,7 @@ import lib.shell3
 
 import unittest
 import tempfile
+import datetime
 
 class TestCheck(unittest.TestCase):
 
@@ -74,7 +75,6 @@ class TestCheck(unittest.TestCase):
         # self.assertRegexpMatches(stdout, r'1 mail to deliver\.')
         self.assertEqual(stderr, '')
         self.assertEqual(retc, STATE_CRIT)
-
 
     # Scenario 1
     # Check if an application creates at least 2 files every 10s, else throw a warning.
@@ -235,6 +235,66 @@ class TestCheck(unittest.TestCase):
         # self.assertRegexpMatches(stdout, r'1 mail to deliver\.')
         self.assertEqual(stderr, '')
         self.assertEqual(retc, STATE_CRIT)
+
+    def test_scenario3_perfdata(self):
+        tmpdir = tempfile.mkdtemp()
+        date_now = datetime.datetime.now()
+        bash = f'''
+        touch -d '{date_now - datetime.timedelta(0, 10)}' {tmpdir}/file1
+        touch -d '{date_now - datetime.timedelta(0, 25)}' {tmpdir}/file2
+        touch -d '{date_now - datetime.timedelta(0, 100)}' {tmpdir}/file3
+        '''
+        lib.base3.coe(lib.shell3.shell_exec('bash', stdin=bash.encode()))
+
+        # the multiple if's serve as a super ugly workaround since assertTrue doesn't support multiple conditions that
+        # are OR-ed against each other and there are some precision problems with touch and certain file systems
+
+        # check mean uneven
+        cmd = f"./file-age3 --filename '{tmpdir}/*' --warning '15:' --warning-count '3:' --critical '20:' --critical-count '2:' --perfdata-mode=mean"
+        stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(cmd))
+        is_valid = False
+        if "Mean: Ages'=44." in stdout:
+            is_valid = True
+        if "Mean: Ages'=45." in stdout:
+            is_valid = True
+        self.assertTrue(is_valid)
+
+        # check median uneven
+        cmd = f"./file-age3 --filename '{tmpdir}/*' --warning '15:' --warning-count '3:' --critical '20:' --critical-count '2:' --perfdata-mode=median"
+        stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(cmd))
+        is_valid = False
+        if "Median: Ages'=24." in stdout:
+            is_valid = True
+        if "Median: Ages'=25." in stdout:
+            is_valid = True
+        self.assertTrue(is_valid)
+
+        # add one file to make it an even file list
+        bash = f'''
+        touch -d '{date_now - datetime.timedelta(0, 200)}' {tmpdir}/file4
+        '''
+        lib.base3.coe(lib.shell3.shell_exec('bash', stdin=bash.encode()))
+
+        # check mean even
+        cmd = f"./file-age3 --filename '{tmpdir}/*' --warning '15:' --warning-count '3:' --critical '20:' --critical-count '2:' --perfdata-mode=mean"
+        stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(cmd))
+        is_valid = False
+        if "Mean: Ages'=83." in stdout:
+            is_valid = True
+        if "Mean: Ages'=82." in stdout:
+            is_valid = True
+        self.assertTrue(is_valid)
+
+        # check median even
+        cmd = f"./file-age3 --filename '{tmpdir}/*' --warning '15:' --warning-count '3:' --critical '20:' --critical-count '2:' --perfdata-mode=median"
+        stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(cmd))
+        is_valid = False
+        if "Median: Ages'=62." in stdout:
+            is_valid = True
+        if "Median: Ages'=61." in stdout:
+            is_valid = True
+        self.assertTrue(is_valid)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hey there 👋
I've added the possibility to enable performance data aggregation on the file_age check.
There are two modes: One calculates the mean (average) over the sum of all checked files and directories. The second mode returns the median from those age checks.
I tried to respect all of your code guidelines and made sure to provide a test case as well. That being said, the test scenario ended up being really ugly and might suffer from inconsistencies as there's some time derivation caused by ``touch`` on certain file systems.
I also only edited the file3.py check since Python 2 dropped their complete support over 2 years ago by now and I don't want to encourage people to make use of something that's considered insecure and abandoned. Feel free to add this logic to the Python2 version as well if you wish to.

Here's the output of the test run on my testing environment:
```
[xxx@xxx file-age]# python --version | python3 --version
Python 2.7.5
Python 3.6.8
[xxx@xxx file-age]# ./test3
.............
----------------------------------------------------------------------
Ran 13 tests in 0.783s

OK
[xxx@xxx file-age]# lsb_release -a
LSB Version:    :core-4.1-amd64:core-4.1-noarch
Distributor ID: CentOS
Description:    CentOS Linux release 7.9.2009 (Core)
Release:        7.9.2009
Codename:       Core
```