### PR TITLE
disk-smart: Properly handle `Power_On_Hours_and_Msec` attribute perfdata parsing

### DIFF
--- a/check-plugins/disk-smart/disk-smart3
+++ b/check-plugins/disk-smart/disk-smart3
@@ -545,6 +545,7 @@ def parse_section_data_subsection_attributes(section):
             if raw_value.isnumeric():
                 raw_value = int(raw_value)
             else:
+                # some drives report something like "45449h+00m+00.000s", for example some SanDisk SSDs
                 raw_value = int(raw_value.split('h', 1)[0])
 
             p['perfdata'][sensor_name] = raw_value

--- a/check-plugins/disk-smart/disk-smart3
+++ b/check-plugins/disk-smart/disk-smart3
@@ -542,7 +542,11 @@ def parse_section_data_subsection_attributes(section):
         if line.startswith('4 Start') \
         or line.startswith('9 Power') \
         or line.startswith('12 Power'):
-            raw_value = int(raw_value)
+            if raw_value.isnumeric():
+                raw_value = int(raw_value)
+            else:
+                raw_value = int(raw_value.split('h', 1)[0])
+
             p['perfdata'][sensor_name] = raw_value
 
     if p['msg']:

--- a/check-plugins/disk-smart/examples/EXAMPLE26
+++ b/check-plugins/disk-smart/examples/EXAMPLE26
@@ -1,0 +1,143 @@
+smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.13.19-4-pve] (local build)
+Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Model Family:     SandForce Driven SSDs
+Device Model:     SanDisk SDSSDA240G
+Serial Number:    xxxxxxxx
+LU WWN Device Id: 5 001b44 4a68489ef
+Firmware Version: Z32080RL
+User Capacity:    240,057,409,536 bytes [240 GB]
+Sector Size:      512 bytes logical/physical
+Rotation Rate:    Solid State Device
+Form Factor:      2.5 inches
+TRIM Command:     Available, deterministic, zeroed
+Device is:        In smartctl database [for details use: -P show]
+ATA Version is:   ACS-2 T13/2015-D revision 3
+SATA Version is:  SATA 3.2, 6.0 Gb/s (current: 6.0 Gb/s)
+Local Time is:    Mon Mar 21 16:38:17 2022 CET
+SMART support is: Available - device has SMART capability.
+SMART support is: Enabled
+AAM feature is:   Unavailable
+APM level is:     254 (maximum performance)
+Rd look-ahead is: Enabled
+Write cache is:   Enabled
+DSN feature is:   Unavailable
+ATA Security is:  Disabled, frozen [SEC2]
+Wt Cache Reorder: Unavailable
+
+=== START OF READ SMART DATA SECTION ===
+SMART overall-health self-assessment test result: PASSED
+
+General SMART Values:
+Offline data collection status:  (0x00)	Offline data collection activity
+					was never started.
+					Auto Offline Data Collection: Disabled.
+Self-test execution status:      (   0)	The previous self-test routine completed
+					without error or no self-test has ever 
+					been run.
+Total time to complete Offline 
+data collection: 		(  120) seconds.
+Offline data collection
+capabilities: 			 (0x11) SMART execute Offline immediate.
+					No Auto Offline data collection support.
+					Suspend Offline collection upon new
+					command.
+					No Offline surface scan supported.
+					Self-test supported.
+					No Conveyance Self-test supported.
+					No Selective Self-test supported.
+SMART capabilities:            (0x0003)	Saves SMART data before entering
+					power-saving mode.
+					Supports SMART auto save timer.
+Error logging capability:        (0x01)	Error logging supported.
+					General Purpose Logging supported.
+Short self-test routine 
+recommended polling time: 	 (   2) minutes.
+Extended self-test routine
+recommended polling time: 	 (  10) minutes.
+
+SMART Attributes Data Structure revision number: 1
+Vendor Specific SMART Attributes with Thresholds:
+ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
+  5 Retired_Block_Count     -O--CK   100   100   000    -    0
+  9 Power_On_Hours_and_Msec -O--CK   000   100   000    -    45449h+00m+00.000s
+ 12 Power_Cycle_Count       -O--CK   100   100   000    -    115
+165 Unknown_Attribute       -O--CK   100   100   000    -    140731045806078
+166 Unknown_Attribute       -O--CK   100   100   000    -    772
+167 Unknown_Attribute       -O--CK   100   100   000    -    0
+168 Unknown_Attribute       -O--CK   100   100   000    -    1473
+169 Unknown_Attribute       -O--CK   100   100   000    -    0
+170 Reserve_Block_Count     -O--CK   100   100   000    -    0
+171 Program_Fail_Count      -O--CK   100   100   000    -    0
+172 Erase_Fail_Count        -O--CK   100   100   000    -    0
+173 Unknown_SandForce_Attr  -O--CK   100   100   000    -    1253
+174 Unexpect_Power_Loss_Ct  -O--CK   100   100   000    -    61
+187 Reported_Uncorrect      -O--CK   100   100   000    -    0
+188 Command_Timeout         -O--CK   100   100   000    -    0
+194 Temperature_Celsius     -O---K   072   046   000    -    28 (Min/Max 0/54)
+199 SATA_CRC_Error_Count    -O--CK   100   100   000    -    0
+230 Life_Curve_Status       -O--CK   100   100   000    -    42946033297167
+232 Available_Reservd_Space PO--CK   100   100   004    -    100
+233 SandForce_Internal      -O--CK   100   100   000    -    293487
+234 SandForce_Internal      -O--CK   100   100   000    -    760014
+241 Lifetime_Writes_GiB     ----CK   253   253   000    -    107464
+242 Lifetime_Reads_GiB      ----CK   253   253   000    -    20256
+244 Unknown_Attribute       -O--CK   000   100   000    -    0
+                            ||||||_ K auto-keep
+                            |||||__ C event count
+                            ||||___ R error rate
+                            |||____ S speed/performance
+                            ||_____ O updated online
+                            |______ P prefailure warning
+
+General Purpose Log Directory Version 1
+SMART           Log Directory Version 1 [multi-sector log support]
+Address    Access  R/W   Size  Description
+0x00       GPL,SL  R/O      1  Log Directory
+0x01           SL  R/O      1  Summary SMART error log
+0x02           SL  R/O      1  Comprehensive SMART error log
+0x03       GPL     R/O      1  Ext. Comprehensive SMART error log
+0x04       GPL,SL  R/O      8  Device Statistics log
+0x06           SL  R/O      1  SMART self-test log
+0x07       GPL     R/O      1  Extended self-test log
+0x10       GPL     R/O      1  NCQ Command Error log
+0x11       GPL     R/O      1  SATA Phy Event Counters log
+0x30       GPL,SL  R/O      9  IDENTIFY DEVICE data log
+0x80-0x9f  GPL,SL  R/W     16  Host vendor specific log
+0xde       GPL     VS       8  Device vendor specific log
+
+SMART Extended Comprehensive Error Log Version: 1 (1 sectors)
+No Errors Logged
+
+SMART Extended Self-test Log Version: 1 (1 sectors)
+No self-tests have been logged.  [To run self-tests, use: smartctl -t]
+
+Selective Self-tests/Logging not supported
+
+SCT Commands not supported
+
+Device Statistics (GP Log 0x04)
+Page  Offset Size        Value Flags Description
+0x01  =====  =               =  ===  == General Statistics (rev 1) ==
+0x01  0x008  4             115  ---  Lifetime Power-On Resets
+0x01  0x010  4           45449  ---  Power-on Hours
+0x01  0x018  6      2030705886  ---  Logical Sectors Written
+0x01  0x020  6      3724238054  ---  Number of Write Commands
+0x01  0x028  6      3826638787  ---  Logical Sectors Read
+0x01  0x030  6       354460905  ---  Number of Read Commands
+0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
+0x07  0x008  1              41  ---  Percentage Used Endurance Indicator
+                                |||_ C monitored condition met
+                                ||__ D supports DSN
+                                |___ N normalized value
+
+Pending Defects log (GP Log 0x0c) not supported
+
+SATA Phy Event Counters (GP Log 0x11)
+ID      Size     Value  Description
+0x0001  4            0  Command failed due to ICRC error
+0x0002  4            0  R_ERR response for data FIS
+0x0005  4            0  R_ERR response for non-data FIS
+0x000a  4            2  Device-to-host register FISes sent due to a COMRESET
+

--- a/check-plugins/disk-smart/test3
+++ b/check-plugins/disk-smart/test3
@@ -294,6 +294,17 @@ class TestCheck(unittest.TestCase):
         self.assertEqual(stderr, '')
         self.assertEqual(retc, STATE_OK)
 
+    def test_if_check_runs_EXAMPLE26(self):
+        stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(self.check + ' --test=examples/EXAMPLE26,,0'))
+        self.assertRegex(stdout, r'All are healthy.')
+        self.assertEqual(stderr, '')
+        self.assertEqual(retc, STATE_OK)
+    def test_if_check_runs_EXAMPLE26_full(self):
+        stdout, stderr, retc = lib.base3.coe(lib.shell3.shell_exec(self.check + ' --full --test=examples/EXAMPLE26,,0'))
+        self.assertRegex(stdout, r'All are healthy.')
+        self.assertEqual(stderr, '')
+        self.assertEqual(retc, STATE_OK)
+
     
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi,

and first many thanks for your great collection of monitoring plugins!

I've just found them - clean structure and output, cross-platform, Icinga Directory Basket configurations - loving it and currently migrating step by step most of my checks to use them where possible. 😍

I had one error when using the `disk-smart` check and some SSDs (namely SanDisk).

The error was when parsing perfdata:
```
bb@vmh-home2:~$ sudo /opt/centralcfg/scripts/icinga/linuxfabrik-monitoring-plugins/disk-smart/disk-smart3
Traceback (most recent call last):
  File "/opt/centralcfg/scripts/icinga/linuxfabrik-monitoring-plugins/disk-smart/disk-smart3", line 910, in 'module'
    main()
  File "/opt/centralcfg/scripts/icinga/linuxfabrik-monitoring-plugins/disk-smart/disk-smart3", line 866, in main
    disk_report = parse_sections(stdout)
  File "/opt/centralcfg/scripts/icinga/linuxfabrik-monitoring-plugins/disk-smart/disk-smart3", line 773, in parse_sections
    report['attributes'] = parse_section_data_subsection_attributes(sections['data_attributes'])
  File "/opt/centralcfg/scripts/icinga/linuxfabrik-monitoring-plugins/disk-smart/disk-smart3", line 545, in parse_section_data_subsection_attributes
    raw_value = int(raw_value)
ValueError: invalid literal for int() with base 10: '45448h+00m+00.000s'
```

Those drives don't have a `Power_On_Hours` integer attribute, but one named `Power_On_Hours_and_Msec` and a value which is not an integer, example:
```
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  9 Power_On_Hours_and_Msec -O--CK   000   100   000    -    45448h+00m+00.000s
```

I've fixed the error / added perfdata parsing of that value and also added a `smartctl` example (EXAMPLE26) and extended the tests.