### PR TITLE
dhcp-scope-usage3: Parse PercentageInUse locale-aware

### DIFF
--- a/check-plugins/dhcp-scope-usage/dhcp-scope-usage3
+++ b/check-plugins/dhcp-scope-usage/dhcp-scope-usage3
@@ -27,6 +27,7 @@ if ACTIVATE_THIS and os.path.isfile(ACTIVATE_THIS):
 
 
 import argparse # pylint: disable=C0413
+import locale # pylint: disable=C0413
 import sys # pylint: disable=C0413
 
 import lib.args3 # pylint: disable=C0413
@@ -187,7 +188,11 @@ def main():
 
         scope = line.split()
         scope_id = scope[0]
-        scope_used = scope[3]
+        
+        # "PercentageInUse" is a floating point number and uses the system locale number format,
+        # so this needs to be parsed locale-aware
+        locale.setlocale(locale.LC_ALL, '') # Use the system default locale
+        scope_used = locale.atof(scope[3])
 
         scope_state = lib.base3.get_state(scope_used, args.WARN, args.CRIT)
         state = lib.base3.get_worst(scope_state, state)


### PR DESCRIPTION
When having a machine with non-english locale settings (e.g. english Windows Server OS, but German localization settings where the decimal separator is a comma instead of a point), `dhcp-scope-usage3` fails with that error due to that the PowerShell output is locale-aware.

```
python C:\centralcfg\scripts\icinga\linuxfabrik-monitoring-plugins\dhcp-scope-usage3
Traceback (most recent call last):
  File "C:\centralcfg\scripts\icinga\linuxfabrik-monitoring-plugins\dhcp-scope-usage3", line 213, in 'module'
    main()
  File "C:\centralcfg\scripts\icinga\linuxfabrik-monitoring-plugins\dhcp-scope-usage3", line 192, in main
    scope_state = lib.base3.get_state(scope_used, args.WARN, args.CRIT)
  File "C:\centralcfg\scripts\icinga\linuxfabrik-monitoring-plugins\lib\base3.py", line 142, in get_state
    value = float(value)
ValueError: could not convert string to float: '35,35353'
```

Example output of `Get-DhcpServerv4ScopeStatistics` on such a system:
```
ScopeId          Free            InUse           PercentageInUse  Reserved        Pending         SuperscopeName 
-------          ----            -----           ---------------  --------        -------         -------------- 
192.168.91.0     64              35              35,35353         0               0     
```

This adds locale-aware parsing (based on the system/user configured locale) for `PercentageInUse`.