### PR TITLE
Add detection of OS Oracle Linux

### DIFF
--- a/check-plugins/about-me/about-me3
+++ b/check-plugins/about-me/about-me3
@@ -340,6 +340,7 @@ def get_nondefault_users():
 def get_os_info():
     release_files = [
         '/etc/centos-release',
+        '/etc/oracle-release',
         '/etc/fedora-release',
         '/etc/redhat-release',
         '/etc/system-release',


### PR DESCRIPTION
On Oracle Linux both files `/etc/redhat-release` and `/etc/oracle-release` are present: Order matters.