### PR TITLE
nextcloud-stats: Fix error non-existing ALWAYS_OK Attribute

### DIFF
--- a/check-plugins/nextcloud-stats/nextcloud-stats3
+++ b/check-plugins/nextcloud-stats/nextcloud-stats3
@@ -39,7 +39,7 @@ from lib.globals3 import STATE_OK, STATE_UNKNOWN # pylint: disable=C0413
 
 
 __author__ = 'Linuxfabrik GmbH, Zurich/Switzerland'
-__version__ = '2023010602'
+__version__ = '2023021301'
 
 DESCRIPTION = """This plugin lets you track the number of active
                 users over time, the number of shares in various categories and some storage

--- a/check-plugins/nextcloud-stats/nextcloud-stats3
+++ b/check-plugins/nextcloud-stats/nextcloud-stats3
@@ -257,7 +257,7 @@ def main():
     perfdata += lib.base3.get_perfdata('nc_active_users_last24h', nc_active_users_last24h, None, None, None, 0, None) # pylint: disable=C0301
 
     # over and out
-    lib.base3.oao(msg, state, perfdata, always_ok=args.ALWAYS_OK)
+    lib.base3.oao(msg, state, perfdata)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello,

thanks for your awesome plugins.

The use of `./nextcloud-stats3 --password ..... --url https://...../ocs/v2.php/apps/serverinfo/api/v1/info --username ....` throws a python error because of the missing ALWAYS_OK attribute, that was removed during code refactoring, removing the missing attribute fixes the error

```
Traceback (most recent call last):
  File "/usr/lib64/nagios/source/nextcloud-stats/./nextcloud-stats3", line 265, in 'module'
    main()
  File "/usr/lib64/nagios/source/nextcloud-stats/./nextcloud-stats3", line 260, in main
    lib.base3.oao(msg, state, perfdata, always_ok=args.ALWAYS_OK)
AttributeError: 'Namespace' object has no attribute 'ALWAYS_OK'
```

afterwards the plugin works as expected.

```
5 users (1/2/3 in the last 5min/1h/24h), 584.0K files, 53 apps, v25.0.3.2
* Shares: 8 (0 groups, 2 links [2 w/o password], 0 mails, 0 rooms, 6 users, 0 federated sent)
* Federated Shares: 0 received
* Storages: 8 (5 home, 0 other, 3 local)
* PHP: v8.1.15, upload_max_filesize=10.0GiB, max_execution_time=3600s, memory_limit=2.0GiB
* DB: mysql v10.10.3, size=632.3MiB
* Web: nginx/1.23.3, local memcache: Memcache\APCu, locking memcache: Memcache\Redis|'nc_system_apps_num_installed'=53;;;0; 'nc_storage_num_users'=5;;;0; 'nc_storage_num_files'=584012;;;0; 'nc_storage_num_storages'=8;;;0; 'nc_storage_num_storages_local'=3;;;0; 'nc_storage_num_storages_home'=5;;;0; 'nc_storage_num_storages_other'=0;;;0; 'nc_shares_num_fed_shares_received'=0;;;0; 'nc_shares_num_fed_shares_sent'=0;;;0; 'nc_shares_num_shares'=8;;;0; 'nc_shares_num_shares_groups'=0;;;0; 'nc_shares_num_shares_link'=2;;;0; 'nc_shares_num_shares_link_no_password'=2;;;0; 'nc_shares_num_shares_mail'=0;;;0; 'nc_shares_num_shares_room'=0;;;0; 'nc_shares_num_shares_user'=6;;;0; 'nc_server_database_size'=663060480B;;;0; 'nc_active_users_last5min'=1;;;0; 'nc_active_users_last1h'=2;;;0; 'nc_active_users_last24h'=3;;;0;
```

Kind regards from Germany,
Robert