### PR TITLE
[disk-smart] skip unsupported disks

### DIFF
--- a/check-plugins/disk-smart/disk-smart
+++ b/check-plugins/disk-smart/disk-smart
@@ -92,6 +92,8 @@ def parse_args():
         '--skip-non-smart',
         help='Skip disks that do not support SMART monitoring.',
         dest='SKIP_NON_SMART',
+        action='store_true',
+        default=False,
     )
 
     return parser.parse_args()

--- a/check-plugins/disk-smart/disk-smart
+++ b/check-plugins/disk-smart/disk-smart
@@ -14,6 +14,7 @@
 import argparse  # pylint: disable=C0413
 import re  # pylint: disable=C0413
 import sys  # pylint: disable=C0413
+import subprocess
 
 import lib.args  # pylint: disable=C0413
 import lib.base  # pylint: disable=C0413

--- a/check-plugins/disk-smart/disk-smart
+++ b/check-plugins/disk-smart/disk-smart
@@ -846,7 +846,7 @@ def main():
 
         status, message = check_smart_support('/dev/' + disk)
 
-        if not disk or disk in args.IGNORE or (lib.base.LINUX and 'disk' not in disk_type) or status != 0:
+        if not disk or disk in args.IGNORE or (lib.base.LINUX and 'disk' not in disk_type) or (args.SKIP_NON_SMART and status != 0):
             continue
 
         if args.TEST is None:

--- a/check-plugins/disk-smart/disk-smart
+++ b/check-plugins/disk-smart/disk-smart
@@ -87,6 +87,12 @@ def parse_args():
         type=lib.args.csv,
     )
 
+    parser.add_argument(
+        '--skip-non-smart',
+        help='Skip disks that do not support SMART monitoring.',
+        dest='SKIP_NON_SMART',
+    )
+
     return parser.parse_args()
 
 
@@ -790,6 +796,15 @@ def parse_sections(smartctl):
 
     return report
 
+def check_smart_support(device):
+    try:
+        output = subprocess.check_output(['smartctl', '-i', device]).decode()
+        if 'SMART support is: Available - device has SMART capability.' in output:
+            return (0, 'Device supports SMART')
+        else:
+            return (2, 'Device does not support SMART')
+    except subprocess.CalledProcessError as e:
+        return (3, 'Error: ' + str(e))
 
 def main():
     """The main function. Hier spielt die Musik.
@@ -827,7 +842,10 @@ def main():
 
     for line in stdout.splitlines():
         disk, disk_type = line.strip().split(maxsplit=1)
-        if not disk or disk in args.IGNORE or (lib.base.LINUX and 'disk' not in disk_type):
+
+        status, message = check_smart_support('/dev/' + disk)
+
+        if not disk or disk in args.IGNORE or (lib.base.LINUX and 'disk' not in disk_type) or status != 0:
             continue
 
         if args.TEST is None:


### PR DESCRIPTION
Currently, the `disk-smart` check will fail if a disk does not support smart (such as external USB hard drives). I propose a simple sanity check to automatically skip disks that do not support smart. This feature is disabled by default and is behind the optional arg `--skip-non-smart`.