### PR TITLE
make fs-ro output better readable

### DIFF
--- a/check-plugins/fs-ro/fs-ro
+++ b/check-plugins/fs-ro/fs-ro
@@ -115,12 +115,12 @@ def main():
 
     # build the message
     if len(ros) > 0:
-        msg = '{} read-only mount {} found: '.format(
+        msg = '{} read-only mount {} found:\n'.format(
             len(ros),
             lib.txt.pluralize('point', len(ros)),
         )
         for item in ros:
-            msg += '{}, '.format(item)
+            msg += '{}\n'.format(item)
         msg = msg[:-2]
         state = STATE_WARN
     else:


### PR DESCRIPTION
The current output is rather hard do digest if there are many read-only filesystems:

![Screenshot 2023-12-11 at 16-31-52 FS RO lx-repos-01 psi ch Services Icinga Web](https://github.com/Linuxfabrik/monitoring-plugins/assets/6852091/5897fa25-ca62-415f-9e1f-8d1bbe642e45)

This pull requests adds a few newlines:

![Screenshot 2023-12-11 at 16-40-44 FS RO lx-repos-01 psi ch Services Icinga Web](https://github.com/Linuxfabrik/monitoring-plugins/assets/6852091/fcd1a279-16ef-4fe0-8b79-b0b1f5bc64da)

which makes it more pleasant to read.