### PR TITLE
fs-ro: show mount point info on first line when there is only one hit

### DIFF
--- a/check-plugins/fs-ro/fs-ro
+++ b/check-plugins/fs-ro/fs-ro
@@ -115,13 +115,13 @@ def main():
 
     # build the message
     if len(ros) > 0:
-        msg = '{} read-only mount {} found:\n'.format(
-            len(ros),
-            lib.txt.pluralize('point', len(ros)),
-        )
-        for item in ros:
-            msg += '* {}\n'.format(item)
-        msg = msg[:-2]
+        if len(ros) == 1:
+            msg = 'read-only mount point found: ' + ros[0]
+        else:
+            msg = '{} read-only mount points found:\n'.format(len(ros))
+            for item in ros:
+                msg += '* {}\n'.format(item)
+
         state = STATE_WARN
     else:
         msg = 'Everything is ok. {} mount {} checked.'.format(cnt, lib.txt.pluralize('point', cnt))


### PR DESCRIPTION
As the first line is treated specially, eg. show in the Icingaweb overview, it would be handy if it would list there when there is just one mount point hit. I guess these are the most interesting cases.

**Tests:**
Single hit
```
[root@test-004 ~]# monitoring-plugins/check-plugins/fs-ro/fs-ro 
read-only mount point found: /dev/loop0 on /mnt/iso (type iso9660)
[root@test-004 ~]#
```

Multiple hits:
```
[root@test-003 ~]# monitoring-plugins/check-plugins/fs-ro/fs-ro 
4 read-only mount points found:
* newperf on /gpfs/perf (type gpfs)
* newtiered on /gpfs/tiered (type gpfs)
* admin on /das/support (type gpfs)
* newphoto on /gpfs/photo (type gpfs)
[root@test-003 ~]# 
```

**PS:**
- The `/dev/loop*` ignore does not work, as this is the device, not the mountpoint
- Would it not make sense to exclude network filesystems? There you do not have the automatic conversion from rw to ro on filesystem corruption.