### PR TITLE
journald-query: also do regex tests case insensitive

### DIFF
--- a/check-plugins/journald-query/journald-query
+++ b/check-plugins/journald-query/journald-query
@@ -254,7 +254,7 @@ def main():
         state = lib.base.str2state(args.SEVERITY)
         result = stdout.splitlines()
 
-        compiled_ignore_regex = [re.compile(item) for item in args.IGNORE_REGEX]
+        compiled_ignore_regex = [re.compile(item, re.IGNORECASE) for item in args.IGNORE_REGEX]
         for item in result:
             try:
                 event = json.loads(item)


### PR DESCRIPTION
I had to search a bit until I understood why

```
[root@lx-dt-01 ~]# journalctl --boot --reverse --priority=emerg..err --since=-8h --unit="sshd.service"
-- Logs begin at Mon 2024-01-22 03:07:35 CET, end at Wed 2024-03-06 17:12:24 CET. --
Mär 06 13:23:57 lx-dt-01.psi.ch sshd[1203315]: error: kex_exchange_identification: Connection closed by remote host
[root@lx-dt-01 ~]# 
```

is not matched by the regex
```
error: kex_exchange_identification: Connection closed by remote host
```