### PR TITLE
ntp-ntpd: Fixed unpacking of ntpq -p values

### DIFF
--- a/check-plugins/ntp-ntpd/ntp-ntpd
+++ b/check-plugins/ntp-ntpd/ntp-ntpd
@@ -102,9 +102,14 @@ def main():
             peer_used = True
             try:
                 # line of peer in the form [tally]remote refid st t when pool reach delay offset jitter
-                peer, refid, stratum, _type, when, poll, reach, delay, offset, jitter = line[1:].split()  # remove '*' and split
-                offset = float(offset)
-                stratum = int(stratum)
+                split_line = line[1:].split()
+
+                # Get numeric values via negativ index as there might be multiple whitespaces in remote
+                peer = split_line[0]
+                stratum = int(split_line[-8])
+                delay = split_line[-3]
+                offset = float(split_line[-2])
+                jitter = split_line[-1]
             except:
                 pass
 


### PR DESCRIPTION
When the chosen ntp Server (maked by *) has one or more whitespaces in its name, the original parsing fails with too many values to unpack. 

Example:
```
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 0.ubuntu.pool.n .POOL.          16 p    -   64    0    0.000    0.000   0.000
 1.ubuntu.pool.n .POOL.          16 p    -   64    0    0.000    0.000   0.000
 2.ubuntu.pool.n .POOL.          16 p    -   64    0    0.000    0.000   0.000
 3.ubuntu.pool.n .POOL.          16 p    -   64    0    0.000    0.000   0.000
 ntp.ubuntu.com  .POOL.          16 p    -   64    0    0.000    0.000   0.000
+mail.gunnarhofm 192.53.103.103   2 u  110  256  377    2.793   -0.228   0.157
-gps.s-buettgen. 131.188.3.222    2 u  164  256  377    3.311    0.129   0.534
+ntp1.kashra-ser 192.168.100.15   2 u  174  256  377   13.709   -0.834   0.278
-47.ip-51-75-67. 17.253.14.251    2 u  156  256  217    4.930   -0.049   0.111
*185.232.69.65 ( 79.133.44.146    2 u  232  256  377    0.398   -0.182   0.170
```

peer, refid, stratum, _type, when, poll, reach, delay, offset, jitter = line[1:].split() 
ValueError: too many values to unpack (expected 10)

A fix is to directly access the variables after remote via a negative index, as every value after is properly sanitized.

I also removed all unused extracted variables.