### PR TITLE
feat(redfish-sel): add support for Supermicro

### DIFF
--- a/check-plugins/redfish-sel/redfish-sel
+++ b/check-plugins/redfish-sel/redfish-sel
@@ -146,9 +146,14 @@ def main():
         ))
         vendor = lib.redfish.get_vendor(result)
 
+        if vendor == 'supermicro':
+            entry_point = 'Systems'
+        else:
+            entry_point = 'Managers'
+
         # Entry point: Get the main data
         result = lib.base.coe(lib.url.fetch_json(
-            '{}/redfish/v1/Managers'.format(args.URL),
+            '{}/redfish/v1/{}'.format(args.URL, entry_point),
             header=header,
             insecure=args.INSECURE,
             no_proxy=args.NO_PROXY,
@@ -193,6 +198,8 @@ def main():
         sel_path = '/LogServices/ActiveLog/Entries'
     elif vendor in ['ts_fujitsu']:
         sel_path = '/LogServices/SystemEventLog/Entries'
+    elif vendor in ['supermicro']:
+        sel_path = '/LogServices/Log1/Entries'
     else:
         sel_path = ''
 


### PR DESCRIPTION
I was able to get the check to work against a Supermicro H13SSL machine with these changes.

The log containing hardware related events (PSU failure, BMC NIC disconnection, etc) is under System on Supermicro, not Manager. The log entries for the Manager on Supermicro contain BMC related events (redfish session created, BMC configuration reset, FW updated started, etc).

If I should take care of bumping the version number or something else, please let me know. 