### PR TITLE
logfile: Ignore decode errors

### DIFF
--- a/check-plugins/logfile/logfile
+++ b/check-plugins/logfile/logfile
@@ -287,7 +287,7 @@ def main():
     crit_matches = []
     line_counter = 0
     try:
-        with open(args.FILENAME) as logfile:
+        with open(args.FILENAME, errors='ignore') as logfile:
             logfile.seek(offset)
             for line in logfile:
                 line_counter += 1


### PR DESCRIPTION
If there are unconforming entries in the input file the python open function can´t parse the input and throws an exception as the default error handling is set to 'strict'. Setting it to 'ignore' skips these characters and lets the exectuion continue.

In our monitoring we have seen the following error a couple of times:
```
Traceback (most recent call last):
  File "logfile.py", line 476, in 'module'
  File "logfile.py", line 292, in main
  File "'frozen codecs'", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x99 in position 3565: invalid start byte
```

The following line was the offending one in the log:
```
2025-07-31T05:15:03.646865+02:00 XXXX [XXXX][1060]: ERROR: <core> [XXXX]: parse_msg(): ERROR: parse_msg: message=<k._#030#031<H^?#010#015#0046e#036X%e#021~#003xek#034=YC#011#bb#016XB&q~nq#007{<99><D2>>
```