### PR TITLE
feat(valkey-status): support user and password credentials, fix tls connection

### DIFF
--- a/check-plugins/valkey-status/README.md
+++ b/check-plugins/valkey-status/README.md
@@ -6,7 +6,7 @@ Returns information and statistics about a Valkey server. Alerts on memory consu
 
 Hints:
 
-* Tested on Valkey 8.0.
+* Tested on Valkey 7.2 and 8.0.
 * "I'm here to keep you safe, Sam. I want to help you." comes from the character GERTY in the movie "Moon" (2009).
 
 
@@ -24,11 +24,11 @@ Hints:
 ## Help
 
 ```text
-usage: valkey-status [-h] [-V] [--always-ok] [-c CRIT] [-H HOSTNAME]
+usage: valkey-status [-h] [-V] [--always-ok] [-c CRIT] [--cacert FILE] [-H HOSTNAME]
                      [--ignore-maxmemory0] [--ignore-overcommit]
                      [--ignore-somaxconn] [--ignore-sync-partial-err]
                      [--ignore-thp] [-p PASSWORD] [--port PORT]
-                     [--socket SOCKET] [--test TEST] [--tls] [-w WARN]
+                     [--socket SOCKET] [--test TEST] [--tls] [-u USER] [--verbose] [-w WARN]
 
 Returns information and statistics about a Valkey server. Alerts on memory
 consumption, memory fragmentation, hit rates and more.
@@ -39,6 +39,7 @@ options:
   --always-ok           Always returns OK.
   -c, --critical CRIT   Set the CRIT threshold as a percentage. Default: >=
                         None
+  --cacert              CA Certificate file to verify with.
   -H, --hostname HOSTNAME
                         Valkey server hostname. Default: 127.0.0.1
   --ignore-maxmemory0   Don't warn about valkey' maxmemory=0. Default: False
@@ -60,6 +61,9 @@ options:
   --test TEST           For unit tests. Needs "path-to-stdout-file,path-to-
                         stderr-file,expected-retc".
   --tls                 Establish a secure TLS connection to Valkey.
+  -u, --user USER
+                        Username to use when connecting to the valkey server.
+  --verbose             Verbose mode helps you debug stuff.
   -w, --warning WARN    Set the WARN threshold as a percentage. Default: >= 90
 ```
 
@@ -157,5 +161,5 @@ net.core.somaxconn is lower than net.ipv4.tcp_max_syn_backlog
 
 ## Credits, License
 
-* Authors: [Linuxfabrik GmbH, Zurich](https://www.linuxfabrik.ch)
+* Authors: [Linuxfabrik GmbH, Zurich](https://www.linuxfabrik.ch); [Claudio Kuenzler](https://www.claudiokuenzler.com)
 * License: The Unlicense, see [LICENSE file](https://unlicense.org/).

--- a/check-plugins/valkey-status/valkey-status
+++ b/check-plugins/valkey-status/valkey-status
@@ -23,8 +23,8 @@ import lib.txt  # pylint: disable=C0413
 from lib.globals import (STATE_CRIT, STATE_OK,  # pylint: disable=C0413
                           STATE_UNKNOWN, STATE_WARN)
 
-__author__ = 'Linuxfabrik GmbH, Zurich/Switzerland'
-__version__ = '2025062901'
+__author__ = 'Linuxfabrik GmbH, Zurich/Switzerland; Claudio Kuenzler'
+__version__ = '2025092401'
 
 DESCRIPTION = """Returns information and statistics about a Valkey server. Alerts on memory
                  consumption, memory fragmentation, hit rates and more."""
@@ -65,6 +65,12 @@ def parse_args():
         dest='CRIT',
         type=int,
         default=DEFAULT_CRIT,
+    )
+
+    parser.add_argument(
+        '--cacert',
+        help='CA Certificate file to verify with.',
+        dest='CACERT',
     )
 
     parser.add_argument(
@@ -154,6 +160,20 @@ def parse_args():
     )
 
     parser.add_argument(
+        '-u', '--user',
+        help='Username to use when connecting to the valkey server.',
+        dest='USER',
+    )
+
+    parser.add_argument(
+        '--verbose',
+        help='Verbose mode helps you debug stuff.',
+        dest='VERBOSE',
+        action='store_true',
+        default=False,
+    )
+
+    parser.add_argument(
         '-w', '--warning',
         help='Set the WARN threshold as a percentage. Default: >= %(default)s',
         dest='WARN',
@@ -178,11 +198,17 @@ def main():
         base_cmd = 'valkey-cli -h {} -p {} '.format(args.HOSTNAME, args.PORT)
     else:
         base_cmd = 'valkey-cli -s {} '.format(args.SOCKET)
-    if args.PASSWORD:
+    if args.PASSWORD and not args.USER:
         base_cmd += '-a {} '.format(args.PASSWORD)
         base_cmd += '--no-auth-warning '
+    if args.PASSWORD and args.USER:
+        base_cmd += '--user {} '.format(args.USER)
+        base_cmd += '--pass {} '.format(args.PASSWORD)
+        base_cmd += '--no-auth-warning '
     if args.TLS:
-        base_cmd += '--tls --cacert /etc/pki/tls/certs/rootCA.pem '
+        base_cmd += '--tls '
+    if args.CACERT:
+        base_cmd += '--cacert {} '.format(args.CACERT)
 
     # fetch data using `valkey-cli info default`
     if args.TEST is None:
@@ -198,6 +224,9 @@ def main():
     if not stdout.startswith('# Server'):
         lib.base.oao(stdout, STATE_WARN)
 
+    # Debug output
+    if args.VERBOSE:
+        print(stdout)
     # parse the output
     lines = stdout.splitlines()
     result = {}
@@ -230,11 +259,12 @@ def main():
 
     # analyze result, get the state and build the message
 
-    # Valkey v8.0.3 (based on Redis v7.2.4), standalone mode on 127.0.0.1:6379, 
+    # Valkey v8.0.3 (based on Redis v7.2.4), standalone mode on 127.0.0.1:6379,
     msg += 'Valkey v{}'.format(result['valkey_version'])
     if 'redis_version' in result:
         msg += ' (based on Redis v{})'.format(result['redis_version'])
-    msg += ', {} mode '.format(result['server_mode'])
+    if 'server_mode' in result:
+        msg += ', {} mode '.format(result['server_mode'])
     if not args.SOCKET:
         msg += 'on {}:{}, '.format(
             args.HOSTNAME,


### PR DESCRIPTION
Thanks for the plugin. It seems to be the only Valkey monitoring plugin around.

This PR adds the possibility to monitor Valkey instances requiring username  and password credentials. Valkey MemoryDBs in AWS for example can set username/password credentials. Without giving the credentials, `valkey-cli` is unable to connect to the remote Valkey instance.

This PR fixes checks on Valkey instances which require a TLS connection. Beforehand a hardcoded line of `--cacert /etc/pki/tls/certs/rootCA.pem` was handed over to `valkey-cli`. This file does not exist, at least not on Ubuntu or Debian - hence leading to an error.

This PR also fixes a bug where `server_mode` key does not exist in the Valkey info output.

This PR also added a `--verbose` parameter to see the full `info default` output of Valkey.

Successfully tested the patched plugin on AWS, using Valkey v7.2.6 (Amazon MemoryDB service), requiring both TLS and Username+Password credentials.