### PR TITLE
add failure-is-critical arg to nextcloud-stats

### DIFF
--- a/check-plugins/nextcloud-stats/README.md
+++ b/check-plugins/nextcloud-stats/README.md
@@ -29,23 +29,26 @@ Tested with Nextcloud 15+.
 
 ```text
 usage: nextcloud-stats [-h] [-V] [--insecure] [--no-proxy] --password PASSWORD
-                       [--timeout TIMEOUT] [--url URL] [--username USERNAME]
+                       [--timeout TIMEOUT] [--failure-is-critical] [--url URL]
+                       [--username USERNAME]
 
 This plugin lets you track the number of active users over time, the number of
 shares in various categories and some storage statistics against a Nextcloud
 server.
 
 options:
-  -h, --help           show this help message and exit
-  -V, --version        show program's version number and exit
-  --insecure           This option explicitly allows to perform "insecure" SSL
-                       connections. Default: False
-  --no-proxy           Do not use a proxy. Default: False
-  --password PASSWORD  Nextcloud API password.
-  --timeout TIMEOUT    Network timeout in seconds. Default: 8 (seconds)
-  --url URL            Nextcloud API URL. Default: http://localhost/nextcloud/
-                       ocs/v2.php/apps/serverinfo/api/v1/info
-  --username USERNAME  Nextcloud API username. Default: admin
+  -h, --help                 show this help message and exit
+  -V, --version              show program's version number and exit
+  --insecure                 This option explicitly allows to perform "insecure" SSL
+                             connections. Default: False
+  --no-proxy                 Do not use a proxy. Default: False
+  --password PASSWORD        Nextcloud API password.
+  --timeout TIMEOUT          Network timeout in seconds. Default: 8 (seconds)
+  --failure-is-critical      Return CRITICAL instead of UNKNOWN when any failure occurs
+                             (timeout, connection error, etc.). Default: False
+  --url URL                  Nextcloud API URL. Default: http://localhost/nextcloud/
+                             ocs/v2.php/apps/serverinfo/api/v1/info
+  --username USERNAME        Nextcloud API username. Default: admin
 ```
 
 
@@ -70,7 +73,9 @@ Output:
 
 ## States
 
-* Always returns OK.
+* Returns OK on success.
+* Returns UNKNOWN on errors (such as connection failures, DNS resolution errors, authentication errors, and timeouts by default).
+* Returns CRITICAL on any failure (timeout, connection error, etc.) when `--failure-is-critical` is used.
 
 
 ## Perfdata / Metrics

--- a/check-plugins/nextcloud-stats/nextcloud-stats
+++ b/check-plugins/nextcloud-stats/nextcloud-stats
@@ -82,10 +82,10 @@ def parse_args():
     )
 
     parser.add_argument(
-        '--timeout-is-critical',
-        help='Return CRITICAL instead of UNKNOWN when a timeout occurs. '
+        '--failure-is-critical',
+        help='Return CRITICAL instead of UNKNOWN when any failure occurs (timeout, connection error, etc.). '
              'Default: %(default)s',
-        dest='TIMEOUT_IS_CRITICAL',
+        dest='FAILURE_IS_CRITICAL',
         action='store_true',
         default=False,
     )
@@ -145,24 +145,12 @@ def main():
     if isinstance(fetch_result, tuple) and len(fetch_result) == 2 and not fetch_result[0]:
         # This is an error
         error_message = fetch_result[1]
-        # Check if this is a timeout error
-        timeout_exceptions = (
-            'timeout',
-            'Timeout',
-            'timed out',
-            'Connection timeout',
-            'Read timeout',
-        )
-        error_str = str(error_message).lower()
-        is_timeout = any(
-            timeout_str.lower() in error_str
-            for timeout_str in timeout_exceptions
-        )
-        if args.TIMEOUT_IS_CRITICAL and is_timeout:
+        if args.FAILURE_IS_CRITICAL:
             lib.base.oao(
-                'Connection timeout occurred while fetching Nextcloud API data.',
+                'Connection failure occurred while fetching Nextcloud API data: {}'.format(error_message),
                 STATE_CRIT,
             )
+            return  # Exit early, oao() should have already exited but just in case
         # Let lib.base.coe() handle the error normally (will return UNKNOWN)
         jsonst = lib.base.coe(fetch_result)
     else:


### PR DESCRIPTION
When the `nextcloud-stats` check has any sort of failure it tends to get buried in the dashboard since UNKNOWN is ranked a lower priority. The new `--failure-is-critical` arg makes any failure return critical without changing the existing behavior.