### PR TITLE
fix(veeam-status): handle camelCase JSON keys from Veeam EM v13 (fix #1001)

### DIFF
--- a/check-plugins/veeam-status/unit-test/run
+++ b/check-plugins/veeam-status/unit-test/run
@@ -52,6 +52,15 @@ TESTS = [
             '"Backup Volume 01" 18.3% used - total: 1005.5GiB, used: 184.2GiB, free: 821.3GiB',
         ],
     },
+    {
+        'id': 'ok-all-healthy-camelcase',
+        'test': 'stdout/all-healthy-camelcase,,0',
+        'params': BASE_PARAMS,
+        'assert-retc': STATE_OK,
+        'assert-in': [
+            '"Backup Volume 01" 18.3% used - total: 1005.5GiB, used: 184.2GiB, free: 821.3GiB',
+        ],
+    },
 ]
 
 

--- a/check-plugins/veeam-status/unit-test/stdout/all-healthy-camelcase
+++ b/check-plugins/veeam-status/unit-test/stdout/all-healthy-camelcase
@@ -1,0 +1,63 @@
+{
+  "job_statistics": {
+    "backupJobStatusReportLink": "Workspace/ViewReport.aspx?definition=7962844d-db6c-4d29-8b6e-4e0f7db0785f&ShowParams=1",
+    "failedJobRuns": 0,
+    "href": "None",
+    "links": "None",
+    "maxBackupJobDuration": 86000,
+    "maxDurationBackupJobName": "Backup_2014-10-18T044119",
+    "maxDurationReplicaJobName": "Fileserver02 Replication",
+    "maxJobDuration": 960,
+    "maxReplicaJobDuration": 50000,
+    "runningJobs": 0,
+    "scheduledBackupJobs": 2,
+    "scheduledJobs": 8,
+    "scheduledReplicaJobs": 0,
+    "successfulJobRuns": 7,
+    "totalJobRuns": 12,
+    "type": "None",
+    "warningsJobRuns": 0
+  },
+  "overview": {
+    "backupServers": 2,
+    "failedVmLastestStates": 0,
+    "href": "None",
+    "links": "None",
+    "proxyServers": 6,
+    "repositoryServers": 6,
+    "runningJobs": 0,
+    "scheduledJobs": 8,
+    "successfulVmLastestStates": 38,
+    "type": "None",
+    "warningVmLastestStates": 0
+  },
+  "repository": {
+    "capacityPlanningReportLink": "Workspace/ViewReport.aspx?definition=62221565-102c-4ec8-851b-d61c03d972d1&ShowParams=1",
+    "href": "None",
+    "links": "None",
+    "periods": [
+      {
+        "name": "Backup Volume 01",
+        "capacity": 1079639011328,
+        "freeSpace": 881812750336,
+        "backupSize": 197826260992
+      }
+    ],
+    "type": "None"
+  },
+  "vms_overview": {
+    "backedUpVms": 38,
+    "fullBackupPointsSize": 1193335981056,
+    "href": "None",
+    "incrementalBackupPointsSize": 0,
+    "links": "None",
+    "protectedVms": 38,
+    "protectedVmsReportLink": "Workspace/ViewReport.aspx?definition=8a56d84f-1790-4f54-ab20-2e0bfdefa16b&ShowParams=1",
+    "replicaRestorePointsSize": 0,
+    "replicatedVms": 2,
+    "restorePoints": 38,
+    "sourceVmsSize": 2950475115008,
+    "successBackupPercents": 100,
+    "type": "None"
+  }
+}

--- a/check-plugins/veeam-status/veeam-status
+++ b/check-plugins/veeam-status/veeam-status
@@ -44,6 +44,19 @@ DEFAULT_WARN = 80
 DEFAULT_WARNING_VM_LASTEST_STATES = 0
 DEFAULT_WARNINGS_JOB_RUNS = 0
 
+def _normalize_keys(obj):
+    """Recursively convert all dict keys to PascalCase.
+
+    Veeam Enterprise Manager v13 changed JSON key serialization from
+    PascalCase (``BackedUpVms``) to camelCase (``backedUpVms``).
+    Normalizing to PascalCase keeps the rest of the code working with
+    both v12 and v13 responses.
+    """
+    if isinstance(obj, dict):
+        return {k[:1].upper() + k[1:]: _normalize_keys(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_normalize_keys(item) for item in obj]
+    return obj
 
 def parse_args():
     """Parse command line arguments using argparse."""
@@ -262,6 +275,11 @@ def main():
         # do not call the command, put in test data
         stdout, _stderr, _retc = lib.lftest.test(args.TEST)
         result = json.loads(stdout)
+
+    # Normalize JSON keys to PascalCase for Veeam v13 compatibility (fix #1001).
+    # Veeam Enterprise Manager v13 returns camelCase keys instead of PascalCase.
+    for key in result:
+        result[key] = _normalize_keys(result[key])
 
     # init some vars
     msg = ''


### PR DESCRIPTION
## Summary

Fixes #1001 — `veeam-status` crashes with `KeyError: 'BackedUpVms'` after
upgrading Veeam from v12 to v13.

## Root Cause

Veeam Enterprise Manager v13 changed JSON key serialization from PascalCase
(`BackedUpVms`) to camelCase (`backedUpVms`) due to the .NET migration. See:
https://community.veeam.com/discussion-boards-66/veeam-enterprise-manager-13-rest-api-json-notation-issue-12234

Veeam confirmed this is an unintended regression on their side that will be
fixed in a future release, but the plugin should be resilient regardless.

## Changes

- Added `_normalize_keys()` helper that recursively converts all dict keys
  to PascalCase (uppercase first letter), applied to every API response
  before processing.
- Added unit test with camelCase test data (`all-healthy-camelcase`) to
  verify the fix.
- Works with both v12 (PascalCase) and v13 (camelCase) responses.

## Testing

All existing unit tests pass unchanged. New camelCase test case passes.