### PR TITLE
ci: create pre-commit autoupdate PRs with a GitHub App token

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -10,12 +10,18 @@ permissions: read-all
 jobs:
   update:
     runs-on: 'ubuntu-latest'
-    permissions:
-      contents: 'write'
-      pull-requests: 'write'
     steps:
+      - name: 'Generate app token'
+        id: 'app-token'
+        uses: 'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1' # v3.2.0
+        with:
+          app-id: '${{ vars.LF_AUTOMATION_APP_ID }}'
+          private-key: '${{ secrets.LF_AUTOMATION_APP_PRIVATE_KEY }}'
+
       - name: 'Checkout repository'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6
+        with:
+          token: '${{ steps.app-token.outputs.token }}'
 
       - name: 'Set up Python'
         uses: 'actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405' # v6
@@ -31,6 +37,7 @@ jobs:
       - name: 'Create Pull Request'
         uses: 'peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1' # v8
         with:
+          token: '${{ steps.app-token.outputs.token }}'
           commit-message: 'chore: update pre-commit hooks'
           title: 'chore: update pre-commit hooks'
           body: 'Automatic pre-commit hook version update.'


### PR DESCRIPTION
Use a GitHub App token (`actions/create-github-app-token`) for checkout and `create-pull-request` instead of the default `GITHUB_TOKEN`.

PRs opened with `GITHUB_TOKEN` do not trigger `pull_request` workflows (GitHub recursion guard), so the required CodeQL and dependency-review checks never ran and the weekly hook-update PRs stayed permanently blocked. With an App token the PRs trigger CI and become mergeable automatically.

Requires org variable `LF_AUTOMATION_APP_ID` and org secret `LF_AUTOMATION_APP_PRIVATE_KEY` (both set), App installed org-wide.