### PR TITLE
bug(args): Quick fix for handling backslash in 'since' parameter in check-plugins/journald-query

### DIFF
--- a/check-plugins/journald-query/journald-query
+++ b/check-plugins/journald-query/journald-query
@@ -335,7 +335,7 @@ def main():
             '--quiet',
             '--output=json',
             f'--priority={args.PRIORITY}',
-            f'--since={args.SINCE}',
+            f'--since={args.SINCE.strip("\\")}',
         ]
         if args.FACILITY:
             cmd.append(f'--facility={args.FACILITY}')


### PR DESCRIPTION
Check command journald-query "since" value since version 6.0.0 cannot be used with default icinga-director basket value:

- Default value "\-8h" for parameter "--since " is given in icingaweb2-module-director journald-query.json, but the command fails when specified
- Currently command ONLY works when parameter is not used (DEFAULT_SINCE)
- As a fix, parameter should be sanitized (by stripping backslashes after arguments are parsed)


### Command used
`'check-plugins/journald-query/journald-query'  '--since' '\-8h'`

### Output
`journalctl --reverse --quiet --output=json --priority=emerg..err --since=\-8h --unit=accounts-daemon.service ...SNIP... --unit=systemd-*.service --unit=user@*.service failed (exit 1): Failed to parse timestamp: \-8h`
