### PR TITLE
fix(deps): align linuxfabrik-lib, setuptools and soupsieve across all lockfiles

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,6 +5,12 @@ on:
 
 permissions: 'read-all'
 
+env:
+  # Lockfiles that have no `directory:` entry in `.github/dependabot.yml`
+  # because upstream packages keep raising their minimum Python. Dependabot
+  # security updates ignore that allowlist, so a bump can still show up here.
+  FROZEN_LOCKFILES: '["/lockfiles/py39", "/lockfiles/py310"]'
+
 jobs:
   auto-merge:
     runs-on: 'ubuntu-latest'
@@ -17,27 +23,29 @@ jobs:
       - uses: 'dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98' # v3.1.0
         id: 'meta'
 
-      # Block bumps against the py39 lockfile. Python 3.9 has been
-      # dropped by most upstream packages over 2025/2026, and
-      # Dependabot does not honour `Requires-Python` when proposing
-      # versions. Dependabot security updates also ignore the
-      # `directory:` allowlist in `.github/dependabot.yml`, so the
-      # freeze has to be enforced here. The py39 lockfile is
-      # maintained manually via `pip-compile` on a Python 3.9 host.
-      - if: "startsWith(steps.meta.outputs.directory, '/lockfiles/py39')"
+      # A bump against a frozen lockfile is left open for a human. Dependabot
+      # does not honour `Requires-Python`, so it may propose a version that
+      # drops the interpreter the lockfile exists for (py39 -> RHEL 8, RHEL 9,
+      # Debian 11; py310 -> Ubuntu 22.04). It may equally propose a security
+      # fix that still supports it. Only a human can tell the two apart, so
+      # the PR is neither merged nor closed. Regenerate the lockfile with
+      # `pip-compile` on a matching Python host once the bump is accepted.
+      - if: >-
+          contains(fromJSON(env.FROZEN_LOCKFILES), steps.meta.outputs.directory)
+          && github.event.action == 'opened'
         run: |
-          gh pr close "$PR_URL" \
-            --comment 'Auto-closed: `lockfiles/py39` is frozen because Python 3.9 is dropped by most upstream packages. Lockfile is maintained manually via pip-compile when an actual fix lands that still supports 3.9.' \
-            --delete-branch
+          gh pr comment "$PR_URL" --body "Not auto-merged: \`${DIRECTORY}\` is frozen because Dependabot does not honour \`Requires-Python\`. Check whether \`${DEPENDENCY}\` still supports that lockfile's interpreter. If it does, regenerate the lockfile with \`pip-compile\` on a matching Python host. Either way, close this PR afterwards."
         env:
-          PR_URL: '${{ github.event.pull_request.html_url }}'
+          DEPENDENCY: '${{ steps.meta.outputs.dependency-names }}'
+          DIRECTORY: '${{ steps.meta.outputs.directory }}'
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          PR_URL: '${{ github.event.pull_request.html_url }}'
 
       - if: >-
-          !startsWith(steps.meta.outputs.directory, '/lockfiles/py39')
+          !contains(fromJSON(env.FROZEN_LOCKFILES), steps.meta.outputs.directory)
           && (steps.meta.outputs.update-type == 'version-update:semver-patch'
               || steps.meta.outputs.update-type == 'version-update:semver-minor')
         run: 'gh pr merge --auto --squash "$PR_URL"'
         env:
-          PR_URL: '${{ github.event.pull_request.html_url }}'
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          PR_URL: '${{ github.event.pull_request.html_url }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Monitoring Plugins:
 
 Build, CI/CD:
 
-* Bump pinned `linuxfabrik-lib` to 5.1.0
+* Bump pinned `linuxfabrik-lib` to 6.0.0
 
 Monitoring Plugins:
 
@@ -76,6 +76,7 @@ Monitoring Plugins:
 Build, CI/CD:
 
 * installer: the source install no longer makes the monitoring user own the plugins, the bundled library and the dependency venv; they stay owned by root, closing a local root code-execution path (the monitoring user could otherwise edit a plugin or library that runs as root via sudo)
+* requirements: the py39 lockfile (RHEL 8, RHEL 9, Debian 11) bundles a `soupsieve` that is not vulnerable to two denial-of-service issues in its CSS selector parser
 
 Monitoring Plugins:
 

--- a/lockfiles/py310/requirements.txt
+++ b/lockfiles/py310/requirements.txt
@@ -347,9 +347,9 @@ keystoneauth1==5.14.0 \
     # via
     #   python-keystoneclient
     #   python-novaclient
-linuxfabrik-lib==5.1.0 \
-    --hash=sha256:163f97ba1fd33edcbcc4493d4c1dc4abbd36c6bf847bd111cfee0ab3bce6c9f5 \
-    --hash=sha256:1f675c9564b5cea0696b1b7a80b502853852507b867c4db579fe97e9054b2296
+linuxfabrik-lib==6.0.0 \
+    --hash=sha256:11fc6fa367e79f2bf5a4dad19989fdebf7fc241438474b88de0037d525ac168e \
+    --hash=sha256:33fa394bce2a2fb40ff6ac01e411d913adccbacc2e7913c7fe808380613cf56f
     # via -r requirements.in
 lxml==6.1.1 \
     --hash=sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2 \

--- a/lockfiles/py310/requirements.txt
+++ b/lockfiles/py310/requirements.txt
@@ -918,7 +918,7 @@ xmltodict==1.0.4 \
     #   pywinrm
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==83.0.0 \
+    --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
+    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
     # via pbr

--- a/lockfiles/py311/requirements.txt
+++ b/lockfiles/py311/requirements.txt
@@ -320,9 +320,9 @@ keystoneauth1==5.15.0 \
     # via
     #   python-keystoneclient
     #   python-novaclient
-linuxfabrik-lib==5.1.0 \
-    --hash=sha256:163f97ba1fd33edcbcc4493d4c1dc4abbd36c6bf847bd111cfee0ab3bce6c9f5 \
-    --hash=sha256:1f675c9564b5cea0696b1b7a80b502853852507b867c4db579fe97e9054b2296
+linuxfabrik-lib==6.0.0 \
+    --hash=sha256:11fc6fa367e79f2bf5a4dad19989fdebf7fc241438474b88de0037d525ac168e \
+    --hash=sha256:33fa394bce2a2fb40ff6ac01e411d913adccbacc2e7913c7fe808380613cf56f
     # via -r requirements.in
 lxml==6.1.1 \
     --hash=sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2 \

--- a/lockfiles/py312/requirements.txt
+++ b/lockfiles/py312/requirements.txt
@@ -320,9 +320,9 @@ keystoneauth1==5.15.0 \
     # via
     #   python-keystoneclient
     #   python-novaclient
-linuxfabrik-lib==5.1.0 \
-    --hash=sha256:163f97ba1fd33edcbcc4493d4c1dc4abbd36c6bf847bd111cfee0ab3bce6c9f5 \
-    --hash=sha256:1f675c9564b5cea0696b1b7a80b502853852507b867c4db579fe97e9054b2296
+linuxfabrik-lib==6.0.0 \
+    --hash=sha256:11fc6fa367e79f2bf5a4dad19989fdebf7fc241438474b88de0037d525ac168e \
+    --hash=sha256:33fa394bce2a2fb40ff6ac01e411d913adccbacc2e7913c7fe808380613cf56f
     # via -r requirements.in
 lxml==6.1.1 \
     --hash=sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2 \

--- a/lockfiles/py312/requirements.txt
+++ b/lockfiles/py312/requirements.txt
@@ -889,7 +889,7 @@ xmltodict==1.0.4 \
     #   pywinrm
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==83.0.0 \
+    --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
+    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
     # via pbr

--- a/lockfiles/py313-windows/requirements.txt
+++ b/lockfiles/py313-windows/requirements.txt
@@ -299,9 +299,9 @@ idna==3.18 \
     #   anyio
     #   httpx
     #   requests
-linuxfabrik-lib==5.1.0 \
-    --hash=sha256:163f97ba1fd33edcbcc4493d4c1dc4abbd36c6bf847bd111cfee0ab3bce6c9f5 \
-    --hash=sha256:1f675c9564b5cea0696b1b7a80b502853852507b867c4db579fe97e9054b2296
+linuxfabrik-lib==6.0.0 \
+    --hash=sha256:11fc6fa367e79f2bf5a4dad19989fdebf7fc241438474b88de0037d525ac168e \
+    --hash=sha256:33fa394bce2a2fb40ff6ac01e411d913adccbacc2e7913c7fe808380613cf56f
     # via -r requirements-py313-windows.in
 lxml==6.1.1 \
     --hash=sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2 \

--- a/lockfiles/py313/requirements.txt
+++ b/lockfiles/py313/requirements.txt
@@ -322,9 +322,9 @@ keystoneauth1==5.14.0 \
     # via
     #   python-keystoneclient
     #   python-novaclient
-linuxfabrik-lib==5.1.0 \
-    --hash=sha256:163f97ba1fd33edcbcc4493d4c1dc4abbd36c6bf847bd111cfee0ab3bce6c9f5 \
-    --hash=sha256:1f675c9564b5cea0696b1b7a80b502853852507b867c4db579fe97e9054b2296
+linuxfabrik-lib==6.0.0 \
+    --hash=sha256:11fc6fa367e79f2bf5a4dad19989fdebf7fc241438474b88de0037d525ac168e \
+    --hash=sha256:33fa394bce2a2fb40ff6ac01e411d913adccbacc2e7913c7fe808380613cf56f
     # via -r requirements.in
 lxml==6.1.1 \
     --hash=sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2 \

--- a/lockfiles/py314/requirements.txt
+++ b/lockfiles/py314/requirements.txt
@@ -322,9 +322,9 @@ keystoneauth1==5.15.0 \
     # via
     #   python-keystoneclient
     #   python-novaclient
-linuxfabrik-lib==5.1.0 \
-    --hash=sha256:163f97ba1fd33edcbcc4493d4c1dc4abbd36c6bf847bd111cfee0ab3bce6c9f5 \
-    --hash=sha256:1f675c9564b5cea0696b1b7a80b502853852507b867c4db579fe97e9054b2296
+linuxfabrik-lib==6.0.0 \
+    --hash=sha256:11fc6fa367e79f2bf5a4dad19989fdebf7fc241438474b88de0037d525ac168e \
+    --hash=sha256:33fa394bce2a2fb40ff6ac01e411d913adccbacc2e7913c7fe808380613cf56f
     # via -r requirements.in
 lxml==6.1.1 \
     --hash=sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2 \

--- a/lockfiles/py39/requirements.txt
+++ b/lockfiles/py39/requirements.txt
@@ -346,9 +346,9 @@ keystoneauth1==5.11.1 \
     # via
     #   python-keystoneclient
     #   python-novaclient
-linuxfabrik-lib==5.1.0 \
-    --hash=sha256:163f97ba1fd33edcbcc4493d4c1dc4abbd36c6bf847bd111cfee0ab3bce6c9f5 \
-    --hash=sha256:1f675c9564b5cea0696b1b7a80b502853852507b867c4db579fe97e9054b2296
+linuxfabrik-lib==6.0.0 \
+    --hash=sha256:11fc6fa367e79f2bf5a4dad19989fdebf7fc241438474b88de0037d525ac168e \
+    --hash=sha256:33fa394bce2a2fb40ff6ac01e411d913adccbacc2e7913c7fe808380613cf56f
     # via -r requirements.in
 lxml==6.1.0 \
     --hash=sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2 \
@@ -777,9 +777,9 @@ smbprotocol==1.16.1 \
     # via
     #   -r requirements.in
     #   linuxfabrik-lib
-soupsieve==2.8.3 \
-    --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
-    --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
+soupsieve==2.8.4 \
+    --hash=sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e \
+    --hash=sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65
     # via beautifulsoup4
 stevedore==5.5.0 \
     --hash=sha256:18363d4d268181e8e8452e71a38cd77630f345b2ef6b4a8d5614dac5ee0d18cf \


### PR DESCRIPTION
Closes the four open Dependabot advisories and a latent breakage on `main`.

## linuxfabrik-lib 5.1.0 -> 6.0.0 (all seven lockfiles)

lib 6.0.0 renamed `lib.huawei` to `lib.huawei_dorado`. The plugins followed that rename in f3ab4b00f, but every lockfile still pinned 5.1.0, which only ships `lib/huawei.py`. A package built from `main` would have failed every `huawei-dorado-*` check with `ModuleNotFoundError` at import time.

No tagged release is affected: `v6.0.0` (2026-06-14) predates the rename (2026-07-03) and pins lib 5.0.0.

Verified in a CI-like checkout (the tracked `lib -> ../lib` symlink dangles, so `import lib.*` resolves to the installed package):

* `linuxfabrik-lib==5.1.0` -> `ModuleNotFoundError: No module named 'lib.huawei_dorado'`, exit 1
* `linuxfabrik-lib==6.0.0` -> plugin starts normally

Dependabot proposed this bump for `py312`, `py313` and `py313-windows` only. `py311` and `py314` were missed; `py39` and `py310` sit outside its `directory:` allowlist. Superseded PRs: #1342, #1343, #1347.

## soupsieve 2.8.3 -> 2.8.4 (py39)

Fixes the ReDoS and memory-exhaustion advisories in the CSS selector parser (Dependabot alerts #52 and #53). soupsieve 2.8.4 still declares `Requires-Python >=3.9`.

Dependabot had already proposed exactly this in #1334, but the `py39` guard in `dependabot-auto-merge.yml` auto-closed it.

## setuptools 82.0.1 -> 83.0.0 (py310, py312)

Dependabot covered `py311`, `py313` and `py314` (#1338, #1344, #1348). 83.0.0 requires Python >= 3.10, so `py310` and `py312` can take it too; it carries the `MANIFEST.in` unicode-normalization fix (GHSA-h35f-9h28-mq5c). `py39` stays on 82.0.1.

## dependabot-auto-merge.yml

The `py39` guard closed *every* Dependabot PR touching that lockfile, including security updates that do still support Python 3.9 - that is how the soupsieve fix was lost. Frozen lockfiles are now commented on and left open for a human.

`py310` is added to the guard. It is excluded in `dependabot.yml` as well, but Dependabot security updates ignore the `directory:` allowlist, so a bump requiring Python 3.11 could previously have auto-merged into it.

## Verification

* `pip install --dry-run --require-hashes` against `py39` (UBI9, Python 3.9.25), `py312` (UBI9/python-312) and `py310` (Ubuntu 22.04, Python 3.10.12 - no RHEL-family image ships 3.10). All resolve.
* `actionlint` clean on the changed workflow.