### PR TITLE
fix(lockfiles): pin setuptools back to 82.0.1 for py39

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,3 +25,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # GHSA-h35f-9h28-mq5c against setuptools in lockfiles/py39. The only
+          # fixed release is 83.0.0, which requires Python 3.10 and therefore
+          # cannot go into the py39 lockfile that RHEL 8, RHEL 9 and Debian 11
+          # install from. The advisory covers MANIFEST.in exclusions being
+          # bypassed while building an sdist on a Unicode-normalizing
+          # filesystem (macOS APFS/HFS+); nothing builds an sdist from this
+          # lockfile, and ext4/xfs do not normalize. Drop this entry once the
+          # py39 lockfile is retired.
+          allow-ghsas: 'GHSA-h35f-9h28-mq5c'

--- a/lockfiles/py39/requirements.txt
+++ b/lockfiles/py39/requirements.txt
@@ -917,7 +917,7 @@ xmltodict==1.0.4 \
     #   pywinrm
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==83.0.0 \
-    --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
-    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
+setuptools==82.0.1 \
+    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
+    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
     # via pbr


### PR DESCRIPTION
setuptools 83.0.0 declares `Requires-Python >=3.10`, so `pip install --require-hashes --requirement lockfiles/py39/requirements.txt` fails on RHEL 8, RHEL 9 and Debian 11. Verified on `registry.access.redhat.com/ubi9/python-39`: pip does not offer 83.0.0 at all there, 82.0.1 resolves.

The bump came in through #1404, which the auto-merge job had deliberately left open with a comment because `/lockfiles/py39` is frozen. It was merged by hand anyway. Nothing was released in between.