### PR TITLE
chore: unify pyproject.toml across repositories

### DIFF
--- a/check-plugins/cert/unit-test/run
+++ b/check-plugins/cert/unit-test/run
@@ -56,7 +56,11 @@ def _make_key(key_type):
 
 
 def make_cert(
-    common_name, days_valid=365, days_offset=0, sans=None, key_type='rsa',
+    common_name,
+    days_valid=365,
+    days_offset=0,
+    sans=None,
+    key_type='rsa',
     with_must_staple=False,
 ):
     """Build a self-signed certificate plus matching private key. `days_offset` shifts
@@ -66,9 +70,11 @@ def make_cert(
     plugin reports as OCSP Must-Staple = yes.
     """
     key = _make_key(key_type)
-    subject = issuer = x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
-    ])
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ]
+    )
     now = lib.time.now(as_type='utc')
     not_before = now + datetime.timedelta(days=days_offset)
     not_after = not_before + datetime.timedelta(days=days_valid)
@@ -137,7 +143,9 @@ def make_chain(leaf_cn, intermediate_cn, leaf_days=60, intermediate_days=3650):
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
         .not_valid_after(now + datetime.timedelta(days=leaf_days))
-        .add_extension(x509.SubjectAlternativeName([x509.DNSName(leaf_cn)]), critical=False)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(leaf_cn)]), critical=False
+        )
         .sign(ca_key, hashes.SHA256())
     )
     leaf_pem = leaf_cert.public_bytes(serialization.Encoding.PEM)
@@ -242,7 +250,6 @@ def load_plugin_module():
 
 
 class TestCheck(unittest.TestCase):
-
     def _serve(self, cert_pem, key_pem):
         srv = TLSServer(cert_pem, key_pem)
         self.addCleanup(srv.close)
@@ -256,8 +263,13 @@ class TestCheck(unittest.TestCase):
         cert_pem, key_pem = make_cert('test.example.com', days_valid=60)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--insecure',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--insecure',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('verification skipped', result.stdout)
@@ -268,8 +280,12 @@ class TestCheck(unittest.TestCase):
         cert_pem, key_pem = make_cert('test.example.com', days_valid=60)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
         )
         self.assertEqual(result.returncode, STATE_WARN, result.stdout)
         self.assertIn('chain unverified', result.stdout)
@@ -278,20 +294,33 @@ class TestCheck(unittest.TestCase):
         cert_pem, key_pem = make_cert('test.example.com', days_valid=60)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--severity', 'crit',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--severity',
+            'crit',
         )
         self.assertEqual(result.returncode, STATE_CRIT, result.stdout)
         self.assertIn('chain unverified', result.stdout)
 
     def test_crit_expired(self):
         cert_pem, key_pem = make_cert(
-            'test.example.com', days_valid=10, days_offset=-30,
+            'test.example.com',
+            days_valid=10,
+            days_offset=-30,
         )
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--insecure',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--insecure',
         )
         self.assertEqual(result.returncode, STATE_CRIT, result.stdout)
         self.assertIn('expired', result.stdout)
@@ -299,25 +328,45 @@ class TestCheck(unittest.TestCase):
 
     def test_warn_low_days(self):
         cert_pem, key_pem = make_cert(
-            'test.example.com', days_valid=10, days_offset=0,
+            'test.example.com',
+            days_valid=10,
+            days_offset=0,
         )
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--insecure',
-            '--warning', '14:', '--critical', '5:',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--insecure',
+            '--warning',
+            '14:',
+            '--critical',
+            '5:',
         )
         self.assertEqual(result.returncode, STATE_WARN, result.stdout)
 
     def test_crit_very_low_days(self):
         cert_pem, key_pem = make_cert(
-            'test.example.com', days_valid=3, days_offset=0,
+            'test.example.com',
+            days_valid=3,
+            days_offset=0,
         )
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--insecure',
-            '--warning', '14:', '--critical', '5:',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--insecure',
+            '--warning',
+            '14:',
+            '--critical',
+            '5:',
         )
         self.assertEqual(result.returncode, STATE_CRIT, result.stdout)
 
@@ -332,26 +381,49 @@ class TestCheck(unittest.TestCase):
         ca_file.close()
         self.addCleanup(os.unlink, ca_file.name)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--ca-file', ca_file.name,
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--ca-file',
+            ca_file.name,
         )
         self.assertEqual(result.returncode, STATE_WARN, result.stdout)
         self.assertIn('Hostname mismatch', result.stdout)
 
     def test_lengthy_includes_all_fields(self):
         cert_pem, key_pem = make_cert(
-            'test.example.com', days_valid=60, sans=['alt1.example.com'],
+            'test.example.com',
+            days_valid=60,
+            sans=['alt1.example.com'],
         )
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--insecure', '--lengthy',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--insecure',
+            '--lengthy',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         for needle in (
-            'Subject CN', 'Issuer CN', 'Serial', 'Signature Algorithm',
-            'Public Key', 'SANs', 'Not Before', 'Not After',
-            'SHA-256 Fingerprint', 'OCSP Must-Staple', 'TLS Version', 'Chain',
+            'Subject CN',
+            'Issuer CN',
+            'Serial',
+            'Signature Algorithm',
+            'Public Key',
+            'SANs',
+            'Not Before',
+            'Not After',
+            'SHA-256 Fingerprint',
+            'OCSP Must-Staple',
+            'TLS Version',
+            'Chain',
             'alt1.example.com',
         ):
             self.assertIn(needle, result.stdout, f'missing {needle}')
@@ -368,8 +440,13 @@ class TestCheck(unittest.TestCase):
         port = sock.getsockname()[1]
         sock.close()
         result = run_plugin(
-            '--source', 'url', '--url', f'https://127.0.0.1:{port}/',
-            '--insecure', '--timeout', '2',
+            '--source',
+            'url',
+            '--url',
+            f'https://127.0.0.1:{port}/',
+            '--insecure',
+            '--timeout',
+            '2',
         )
         self.assertEqual(result.returncode, STATE_UNKNOWN, result.stdout)
         self.assertIn('Cannot connect', result.stdout)
@@ -381,12 +458,20 @@ class TestCheck(unittest.TestCase):
 
     def test_lengthy_ecdsa_key(self):
         cert_pem, key_pem = make_cert(
-            'test.example.com', days_valid=60, key_type='ecdsa',
+            'test.example.com',
+            days_valid=60,
+            key_type='ecdsa',
         )
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--insecure', '--lengthy',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--insecure',
+            '--lengthy',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         # cryptography exposes EC keys as ECPublicKey, so the plugin labels them "EC"
@@ -396,12 +481,20 @@ class TestCheck(unittest.TestCase):
 
     def test_lengthy_ed25519_key(self):
         cert_pem, key_pem = make_cert(
-            'test.example.com', days_valid=60, key_type='ed25519',
+            'test.example.com',
+            days_valid=60,
+            key_type='ed25519',
         )
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--insecure', '--lengthy',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--insecure',
+            '--lengthy',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('Ed25519', result.stdout)
@@ -410,8 +503,13 @@ class TestCheck(unittest.TestCase):
         cert_pem, key_pem = make_cert('test.example.com', days_valid=60)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'test.example.com', '--always-ok',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'test.example.com',
+            '--always-ok',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('chain unverified', result.stdout)
@@ -420,26 +518,46 @@ class TestCheck(unittest.TestCase):
         # issued 50 days ago, valid 60 days -> ~10 days left = ~17% of the lifetime, so a
         # 25% warning threshold fires while the 5% critical does not
         cert_pem, key_pem = make_cert(
-            'pct.example.com', days_valid=60, days_offset=-50,
+            'pct.example.com',
+            days_valid=60,
+            days_offset=-50,
         )
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'pct.example.com', '--insecure',
-            '--warning', '25%', '--critical', '5%',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'pct.example.com',
+            '--insecure',
+            '--warning',
+            '25%',
+            '--critical',
+            '5%',
         )
         self.assertEqual(result.returncode, STATE_WARN, result.stdout)
 
     def test_crit_duration_threshold(self):
         # ~2 days left, critical when less than 3 days remain
         cert_pem, key_pem = make_cert(
-            'iv.example.com', days_valid=60, days_offset=-58,
+            'iv.example.com',
+            days_valid=60,
+            days_offset=-58,
         )
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'iv.example.com', '--insecure',
-            '--warning', '14d', '--critical', '3d',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'iv.example.com',
+            '--insecure',
+            '--warning',
+            '14d',
+            '--critical',
+            '3d',
         )
         self.assertEqual(result.returncode, STATE_CRIT, result.stdout)
 
@@ -453,9 +571,16 @@ class TestCheck(unittest.TestCase):
         ca_file.close()
         self.addCleanup(os.unlink, ca_file.name)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'ca.example.com',
-            '--ca-file', ca_file.name, '--ca-file', ca_file.name,
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'ca.example.com',
+            '--ca-file',
+            ca_file.name,
+            '--ca-file',
+            ca_file.name,
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('chain verified', result.stdout)
@@ -469,14 +594,24 @@ class TestCheck(unittest.TestCase):
         # inspect the whole peer chain, raise WARN and surface the intermediate as the
         # soonest-expiring certificate
         leaf_pem, intermediate_pem, leaf_key_pem = make_chain(
-            'chain.example.com', 'Test Intermediate CA',
-            leaf_days=60, intermediate_days=7,
+            'chain.example.com',
+            'Test Intermediate CA',
+            leaf_days=60,
+            intermediate_days=7,
         )
         port = self._serve(leaf_pem + intermediate_pem, leaf_key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'chain.example.com', '--insecure',
-            '--warning', '14:', '--critical', '5:',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'chain.example.com',
+            '--insecure',
+            '--warning',
+            '14:',
+            '--critical',
+            '5:',
         )
         self.assertEqual(result.returncode, STATE_WARN, result.stdout)
         self.assertIn('Test Intermediate CA', result.stdout)
@@ -487,12 +622,19 @@ class TestCheck(unittest.TestCase):
     )
     def test_chain_lengthy_shows_each_cert(self):
         leaf_pem, intermediate_pem, leaf_key_pem = make_chain(
-            'chain.example.com', 'Test Intermediate CA',
+            'chain.example.com',
+            'Test Intermediate CA',
         )
         port = self._serve(leaf_pem + intermediate_pem, leaf_key_pem)
         result = run_plugin(
-            '--source', 'url', '--url', self._url(port),
-            '--sni-hostname', 'chain.example.com', '--insecure', '--lengthy',
+            '--source',
+            'url',
+            '--url',
+            self._url(port),
+            '--sni-hostname',
+            'chain.example.com',
+            '--insecure',
+            '--lengthy',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         # both the leaf and the intermediate get their own --lengthy block
@@ -535,7 +677,9 @@ class TestFileSource(unittest.TestCase):
 
     def test_crit_expired_file(self):
         cert_pem, _ = make_cert(
-            'test.example.com', days_valid=10, days_offset=-30,
+            'test.example.com',
+            days_valid=10,
+            days_offset=-30,
         )
         path = self._write(cert_pem)
         result = run_plugin('--source', 'file', '--filename', path)
@@ -557,7 +701,9 @@ class TestFileSource(unittest.TestCase):
         # in a single bundle file must surface the expired intermediate as CRIT.
         leaf_pem, _ = make_cert('leaf.example.com', days_valid=60)
         expired_intermediate_pem, _ = make_cert(
-            'old.intermediate.example.com', days_valid=10, days_offset=-30,
+            'old.intermediate.example.com',
+            days_valid=10,
+            days_offset=-30,
         )
         path = self._write(leaf_pem + expired_intermediate_pem)
         result = run_plugin('--source', 'file', '--filename', path)
@@ -573,8 +719,14 @@ class TestFileSource(unittest.TestCase):
                 with open(os.path.join(tmpdir, name), 'wb') as fh:
                     fh.write(data)
             result = run_plugin(
-                '--source', 'file', '--filename', f'{tmpdir}/*.pem',
-                '--warning', '14:', '--critical', '5:',
+                '--source',
+                'file',
+                '--filename',
+                f'{tmpdir}/*.pem',
+                '--warning',
+                '14:',
+                '--critical',
+                '5:',
             )
         self.assertEqual(result.returncode, STATE_WARN, result.stdout)
         self.assertIn('2 certificates in', result.stdout)
@@ -584,7 +736,10 @@ class TestFileSource(unittest.TestCase):
 
     def test_unknown_no_match(self):
         result = run_plugin(
-            '--source', 'file', '--filename', '/tmp/lfmp-cert-no-such-file-*.pem',
+            '--source',
+            'file',
+            '--filename',
+            '/tmp/lfmp-cert-no-such-file-*.pem',
         )
         self.assertEqual(result.returncode, STATE_UNKNOWN, result.stdout)
         self.assertIn('No files match', result.stdout)
@@ -622,7 +777,10 @@ class TestFileSource(unittest.TestCase):
             with open(os.path.join(tmpdir, 'a/b/c/notes.txt'), 'wb') as fh:
                 fh.write(b'shopping list')
             result = run_plugin(
-                '--source', 'file', '--filename', f'{tmpdir}/**/*',
+                '--source',
+                'file',
+                '--filename',
+                f'{tmpdir}/**/*',
             )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('2 certificates in', result.stdout)
@@ -636,7 +794,11 @@ class TestFileSource(unittest.TestCase):
         cert_pem, _ = make_cert('test.example.com', days_valid=60)
         path = self._write(cert_pem)
         result = run_plugin(
-            '--source', 'file', '--filename', path, '--lengthy',
+            '--source',
+            'file',
+            '--filename',
+            path,
+            '--lengthy',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('Subject CN', result.stdout)
@@ -650,12 +812,18 @@ class TestFileSource(unittest.TestCase):
         # add the TLS Feature extension carrying status_request (5) so the parser sees
         # OCSP Must-Staple set; cryptography exposes this via x509.TLSFeature
         cert_pem, _ = make_cert(
-            'staple.example.com', days_valid=60, key_type='rsa',
+            'staple.example.com',
+            days_valid=60,
+            key_type='rsa',
             with_must_staple=True,
         )
         path = self._write(cert_pem)
         result = run_plugin(
-            '--source', 'file', '--filename', path, '--lengthy',
+            '--source',
+            'file',
+            '--filename',
+            path,
+            '--lengthy',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertRegex(result.stdout, r'OCSP Must-Staple\s*!\s*yes')
@@ -677,7 +845,9 @@ class TestScanSource(unittest.TestCase):
     def test_scan_ok_single_host(self):
         cert_pem, key_pem = make_cert('scan.example.com', days_valid=60)
         port = self._serve(cert_pem, key_pem)
-        result = run_plugin('--source', 'scan', '--host', '127.0.0.1', '--ports', str(port))
+        result = run_plugin(
+            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port)
+        )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         # a scan always uses the table form, even for a single certificate
         self.assertIn('1/1 host responded', result.stdout)
@@ -696,9 +866,18 @@ class TestScanSource(unittest.TestCase):
         p_ok = self._serve(ok_pem, ok_key)
         p_warn = self._serve(warn_pem, warn_key)
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1',
-            '--ports', str(p_ok), '--ports', str(p_warn),
-            '--warning', '14:', '--critical', '5:',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(p_ok),
+            '--ports',
+            str(p_warn),
+            '--warning',
+            '14:',
+            '--critical',
+            '5:',
         )
         self.assertEqual(result.returncode, STATE_WARN, result.stdout)
         # one host answered on two ports: 1 host, 2 certificates
@@ -711,7 +890,12 @@ class TestScanSource(unittest.TestCase):
         port = self._serve(cert_pem, key_pem)
         # a one-port range start-end that covers exactly the listener port
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', f'{port}-{port}',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            f'{port}-{port}',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('range.example.com', result.stdout)
@@ -719,15 +903,23 @@ class TestScanSource(unittest.TestCase):
     def test_scan_crit_expired(self):
         cert_pem, key_pem = make_cert('old.example.com', days_valid=10, days_offset=-30)
         port = self._serve(cert_pem, key_pem)
-        result = run_plugin('--source', 'scan', '--host', '127.0.0.1', '--ports', str(port))
+        result = run_plugin(
+            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port)
+        )
         self.assertEqual(result.returncode, STATE_CRIT, result.stdout)
         self.assertIn('expired', result.stdout)
 
     def test_scan_no_responders(self):
         port = closed_port()
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port),
-            '--timeout', '2',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(port),
+            '--timeout',
+            '2',
         )
         # nothing answered: not an error, just nothing to alert on
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
@@ -740,7 +932,13 @@ class TestScanSource(unittest.TestCase):
         cert_pem, key_pem = make_cert('scan.example.com', days_valid=60)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port), '--lengthy',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(port),
+            '--lengthy',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('TLS Version', result.stdout)
@@ -750,8 +948,14 @@ class TestScanSource(unittest.TestCase):
 
     def test_scan_exclude_removes_all_hosts(self):
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--exclude', '127.0.0.1',
-            '--ports', '443',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--exclude',
+            '127.0.0.1',
+            '--ports',
+            '443',
         )
         self.assertEqual(result.returncode, STATE_UNKNOWN, result.stdout)
         self.assertIn('No target hosts', result.stdout)
@@ -767,7 +971,13 @@ class TestScanSource(unittest.TestCase):
         cert_pem, key_pem = make_cert('appliance.local', days_valid=60)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port), '--lengthy',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(port),
+            '--lengthy',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('self-signed', result.stdout)
@@ -776,31 +986,48 @@ class TestScanSource(unittest.TestCase):
         # leaf signed by an internal CA, but the server presents only the leaf and the CA
         # is not trusted: not self-signed, so the trust check fails and raises WARN
         leaf_pem, _intermediate_pem, leaf_key_pem = make_chain(
-            'app.example.com', 'Internal CA',
+            'app.example.com',
+            'Internal CA',
         )
         port = self._serve(leaf_pem, leaf_key_pem)
-        result = run_plugin('--source', 'scan', '--host', '127.0.0.1', '--ports', str(port))
+        result = run_plugin(
+            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port)
+        )
         self.assertEqual(result.returncode, STATE_WARN, result.stdout)
 
     def test_scan_untrusted_insecure_ok(self):
         # --insecure turns trust verification off entirely, so the untrusted cert is OK
         leaf_pem, _intermediate_pem, leaf_key_pem = make_chain(
-            'app.example.com', 'Internal CA',
+            'app.example.com',
+            'Internal CA',
         )
         port = self._serve(leaf_pem, leaf_key_pem)
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port), '--insecure',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(port),
+            '--insecure',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
 
     def test_scan_untrusted_severity_crit(self):
         leaf_pem, _intermediate_pem, leaf_key_pem = make_chain(
-            'app.example.com', 'Internal CA',
+            'app.example.com',
+            'Internal CA',
         )
         port = self._serve(leaf_pem, leaf_key_pem)
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port),
-            '--severity', 'crit',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(port),
+            '--severity',
+            'crit',
         )
         self.assertEqual(result.returncode, STATE_CRIT, result.stdout)
 
@@ -865,8 +1092,16 @@ class TestWorkerBudget(unittest.TestCase):
         cert_pem, key_pem = make_cert('scan.example.com', days_valid=60)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port),
-            '--insecure', '--max-workers', '5000', '--verbose',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(port),
+            '--insecure',
+            '--max-workers',
+            '5000',
+            '--verbose',
             nofile=(128, 128),
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
@@ -876,7 +1111,13 @@ class TestWorkerBudget(unittest.TestCase):
         cert_pem, key_pem = make_cert('scan.example.com', days_valid=60)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port), '--insecure',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(port),
+            '--insecure',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         # one target, so the scan needs exactly one worker, and the noun is singular
@@ -887,15 +1128,27 @@ class TestWorkerBudget(unittest.TestCase):
         cert_pem, key_pem = make_cert('scan.example.com', days_valid=10)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port), '--insecure',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(port),
+            '--insecure',
         )
         self.assertEqual(result.returncode, STATE_WARN, result.stdout)
         self.assertRegex(result.stdout.splitlines()[0], r', 1 worker \[WARNING\]$')
 
     def test_scan_without_any_response_reports_the_worker_count(self):
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1',
-            '--ports', str(closed_port()), '--timeout', '2',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(closed_port()),
+            '--timeout',
+            '2',
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('0/1 host responded, 1 worker', result.stdout)
@@ -907,8 +1160,13 @@ class TestWorkerBudget(unittest.TestCase):
         """
         plugin = self.plugin
         args = argparse.Namespace(
-            CA_FILE=[], CLIENT_CERT=None, CLIENT_KEY=None, INSECURE=False,
-            MAX_WORKERS=4, TIMEOUT=1, VERBOSE=False,
+            CA_FILE=[],
+            CLIENT_CERT=None,
+            CLIENT_KEY=None,
+            INSECURE=False,
+            MAX_WORKERS=4,
+            TIMEOUT=1,
+            VERBOSE=False,
         )
         ok, contexts = plugin.build_scan_contexts(args)
         self.assertTrue(ok, contexts)
@@ -922,7 +1180,11 @@ class TestWorkerBudget(unittest.TestCase):
 
         ports = [closed_port() for _ in range(4)]
         ok, result = plugin.scan_targets(
-            args, ['127.0.0.1'], ports, verify_ctx, insecure_ctx,
+            args,
+            ['127.0.0.1'],
+            ports,
+            verify_ctx,
+            insecure_ctx,
         )
         self.assertTrue(ok, result)
         items, workers = result
@@ -931,7 +1193,10 @@ class TestWorkerBudget(unittest.TestCase):
 
     def test_build_scan_contexts_skips_verification_with_insecure(self):
         args = argparse.Namespace(
-            CA_FILE=[], CLIENT_CERT=None, CLIENT_KEY=None, INSECURE=True,
+            CA_FILE=[],
+            CLIENT_CERT=None,
+            CLIENT_KEY=None,
+            INSECURE=True,
         )
         ok, (verify_ctx, insecure_ctx) = self.plugin.build_scan_contexts(args)
         self.assertTrue(ok)
@@ -940,7 +1205,9 @@ class TestWorkerBudget(unittest.TestCase):
 
     def test_build_scan_contexts_reports_a_broken_ca_file(self):
         args = argparse.Namespace(
-            CA_FILE=['/nonexistent/ca.pem'], CLIENT_CERT=None, CLIENT_KEY=None,
+            CA_FILE=['/nonexistent/ca.pem'],
+            CLIENT_CERT=None,
+            CLIENT_KEY=None,
             INSECURE=False,
         )
         ok, result = self.plugin.build_scan_contexts(args)
@@ -953,7 +1220,13 @@ class TestWorkerBudget(unittest.TestCase):
         cert_pem, key_pem = make_cert('scan.example.com', days_valid=60)
         port = self._serve(cert_pem, key_pem)
         result = run_plugin(
-            '--source', 'scan', '--host', '127.0.0.1', '--ports', str(port), '--insecure',
+            '--source',
+            'scan',
+            '--host',
+            '127.0.0.1',
+            '--ports',
+            str(port),
+            '--insecure',
             nofile=(128, 128),
         )
         self.assertEqual(result.returncode, STATE_OK, result.stdout)

--- a/check-plugins/fs-inodes/fs-inodes
+++ b/check-plugins/fs-inodes/fs-inodes
@@ -218,7 +218,9 @@ def main():
         if not success:
             table_data.append(
                 {
-                    'mountpoint': lib.disk.shorten_path(mount, max_len=DISPLAY_PATH_MAXLEN),
+                    'mountpoint': lib.disk.shorten_path(
+                        mount, max_len=DISPLAY_PATH_MAXLEN
+                    ),
                     'device': disk.get('dmd') or disk['bd'],
                     'iused': 'N/A',
                     'ifree': 'N/A',
@@ -284,9 +286,7 @@ def main():
         msg = f'{header} ({thresholds})\n\n{table}'
     else:
         # default: a compact single line, one item per mount point.
-        msg = ', '.join(
-            f'{row["mountpoint"]} {row["percent"]}' for row in table_data
-        )
+        msg = ', '.join(f'{row["mountpoint"]} {row["percent"]}' for row in table_data)
         if state != STATE_OK:
             msg += '. Have a look at the README on how to find where inodes are being used.'
 

--- a/check-plugins/fs-inodes/unit-test/run
+++ b/check-plugins/fs-inodes/unit-test/run
@@ -159,7 +159,6 @@ TESTS = [
 
 
 class TestCheck(unittest.TestCase):
-
     check = '../fs-inodes'
 
 

--- a/check-plugins/kdump/unit-test/run
+++ b/check-plugins/kdump/unit-test/run
@@ -120,7 +120,6 @@ TESTS = [
 
 
 class TestCheck(unittest.TestCase):
-
     check = '../kdump'
 
 

--- a/check-plugins/mysql-index-health/unit-test/run
+++ b/check-plugins/mysql-index-health/unit-test/run
@@ -53,7 +53,8 @@ from lib.globals import STATE_OK, STATE_UNKNOWN, STATE_WARN
 HERE = os.path.dirname(os.path.abspath(__file__))
 CONTAINERFILES_DIR = os.path.join(HERE, 'containerfiles')
 CONTAINERFILES = sorted(
-    name for name in os.listdir(CONTAINERFILES_DIR)
+    name
+    for name in os.listdir(CONTAINERFILES_DIR)
     if os.path.isfile(os.path.join(CONTAINERFILES_DIR, name))
 )
 
@@ -65,7 +66,8 @@ class TestCheck(unittest.TestCase):
 def _run_plugin(defaults_file):
     return subprocess.run(
         [
-            'python3', '../mysql-index-health',
+            'python3',
+            '../mysql-index-health',
             f'--defaults-file={defaults_file}',
             # Disable the 24h warmup gate so the unit test can observe
             # findings on a freshly booted container (Uptime starts at 0).
@@ -82,13 +84,16 @@ def _exec_sql(container, sql):
     families (mariadb / mysql) and the sclorg-vs-upstream root-auth
     difference (sclorg root uses socket auth, upstream uses password).
     """
-    container.exec([
-        'sh', '-c',
-        'if command -v mariadb >/dev/null 2>&1; then C=mariadb; '
-        'else C=mysql; fi; '
-        f'"$C" -uroot -e "{sql}" 2>/dev/null '
-        f'|| "$C" -uroot -ptest -e "{sql}"',
-    ])
+    container.exec(
+        [
+            'sh',
+            '-c',
+            'if command -v mariadb >/dev/null 2>&1; then C=mariadb; '
+            'else C=mysql; fi; '
+            f'"$C" -uroot -e "{sql}" 2>/dev/null '
+            f'|| "$C" -uroot -ptest -e "{sql}"',
+        ]
+    )
 
 
 def _check_image(test, containerfile):
@@ -129,7 +134,7 @@ def _check_image(test, containerfile):
         # `sys.schema_unused_indexes` view simply stays empty.
         _exec_sql(
             container,
-            "UPDATE performance_schema.setup_consumers "
+            'UPDATE performance_schema.setup_consumers '
             "SET ENABLED = 'YES' WHERE NAME LIKE 'global_instrumentation';",
         )
 
@@ -140,8 +145,8 @@ def _check_image(test, containerfile):
         # enough without being queried via idx_a.
         _exec_sql(
             container,
-            "CREATE DATABASE t; USE t; "
-            "CREATE TABLE x (a INT, b INT, KEY idx_a(a), KEY idx_a_b(a,b));",
+            'CREATE DATABASE t; USE t; '
+            'CREATE TABLE x (a INT, b INT, KEY idx_a(a), KEY idx_a_b(a,b));',
         )
 
         # Phase 3: re-run with findings present. Behaviour differs

--- a/check-plugins/redfish-ethernetinterfaces/redfish-ethernetinterfaces
+++ b/check-plugins/redfish-ethernetinterfaces/redfish-ethernetinterfaces
@@ -32,7 +32,9 @@ because an unused interface being down is a normal condition. System-level healt
 ignored by this check; use `redfish-systems` for that."""
 
 API_BASE = '/redfish/v1'
-DEFAULT_CACHE_EXPIRE = 5  # minutes; also caches API responses, kept below the session timeout
+DEFAULT_CACHE_EXPIRE = (
+    5  # minutes; also caches API responses, kept below the session timeout
+)
 DEFAULT_INSECURE = True
 DEFAULT_NO_PROXY = False
 DEFAULT_RETRIES = 3  # extra attempts on a failed Redfish request

--- a/check-plugins/redfish-firmwareinventory/redfish-firmwareinventory
+++ b/check-plugins/redfish-firmwareinventory/redfish-firmwareinventory
@@ -30,7 +30,9 @@ Lists every firmware component with its installed version and identification, an
 component reports a degraded or failed health state."""
 
 API_BASE = '/redfish/v1'
-DEFAULT_CACHE_EXPIRE = 5  # minutes; also caches API responses, kept below the session timeout
+DEFAULT_CACHE_EXPIRE = (
+    5  # minutes; also caches API responses, kept below the session timeout
+)
 DEFAULT_INSECURE = True
 DEFAULT_NO_PROXY = False
 DEFAULT_RETRIES = 3  # extra attempts on a failed Redfish request

--- a/check-plugins/redfish-logservices/redfish-logservices
+++ b/check-plugins/redfish-logservices/redfish-logservices
@@ -34,7 +34,9 @@ days can be aged out so a long-since resolved event does not keep the check in a
 forever."""
 
 API_BASE = '/redfish/v1'
-DEFAULT_CACHE_EXPIRE = 5  # minutes; also caches API responses, kept below the session timeout
+DEFAULT_CACHE_EXPIRE = (
+    5  # minutes; also caches API responses, kept below the session timeout
+)
 DEFAULT_INSECURE = True
 DEFAULT_LOG_TYPE = 'sel'
 DEFAULT_MAX_AGE = 0  # days; 0 disables aging

--- a/check-plugins/redfish-managers/redfish-managers
+++ b/check-plugins/redfish-managers/redfish-managers
@@ -32,7 +32,9 @@ alerts whenever any manager's status leaves `OK`. Use `redfish-logservices` to i
 event log."""
 
 API_BASE = '/redfish/v1'
-DEFAULT_CACHE_EXPIRE = 5  # minutes; also caches API responses, kept below the session timeout
+DEFAULT_CACHE_EXPIRE = (
+    5  # minutes; also caches API responses, kept below the session timeout
+)
 DEFAULT_INSECURE = True
 DEFAULT_NO_PROXY = False
 DEFAULT_RETRIES = 3  # extra attempts on a failed Redfish request

--- a/check-plugins/redfish-memory/redfish-memory
+++ b/check-plugins/redfish-memory/redfish-memory
@@ -32,7 +32,9 @@ this check so that a system warning unrelated to memory does not mask the module
 `redfish-systems` for that."""
 
 API_BASE = '/redfish/v1'
-DEFAULT_CACHE_EXPIRE = 5  # minutes; also caches API responses, kept below the session timeout
+DEFAULT_CACHE_EXPIRE = (
+    5  # minutes; also caches API responses, kept below the session timeout
+)
 DEFAULT_INSECURE = True
 DEFAULT_NO_PROXY = False
 DEFAULT_RETRIES = 3  # extra attempts on a failed Redfish request

--- a/check-plugins/redfish-processors/redfish-processors
+++ b/check-plugins/redfish-processors/redfish-processors
@@ -32,7 +32,9 @@ so that a system warning unrelated to processors does not mask the processor sta
 `redfish-systems` for that."""
 
 API_BASE = '/redfish/v1'
-DEFAULT_CACHE_EXPIRE = 5  # minutes; also caches API responses, kept below the session timeout
+DEFAULT_CACHE_EXPIRE = (
+    5  # minutes; also caches API responses, kept below the session timeout
+)
 DEFAULT_INSECURE = True
 DEFAULT_NO_PROXY = False
 DEFAULT_RETRIES = 3  # extra attempts on a failed Redfish request

--- a/check-plugins/redfish-sensors/redfish-sensors
+++ b/check-plugins/redfish-sensors/redfish-sensors
@@ -31,7 +31,9 @@ available and falls back to the legacy Thermal and Power endpoints otherwise. Al
 sensor reports a non-ok state."""
 
 API_BASE = '/redfish/v1'
-DEFAULT_CACHE_EXPIRE = 5  # minutes; also caches API responses, kept below the session timeout
+DEFAULT_CACHE_EXPIRE = (
+    5  # minutes; also caches API responses, kept below the session timeout
+)
 DEFAULT_INSECURE = True
 DEFAULT_NO_PROXY = False
 DEFAULT_RETRIES = 3  # extra attempts on a failed Redfish request

--- a/check-plugins/redfish-storage/redfish-storage
+++ b/check-plugins/redfish-storage/redfish-storage
@@ -32,7 +32,9 @@ indicator LED, etc.) is deliberately ignored by this check so that a system warn
 to storage does not mask the storage status; use `redfish-systems` for that."""
 
 API_BASE = '/redfish/v1'
-DEFAULT_CACHE_EXPIRE = 5  # minutes; also caches API responses, kept below the session timeout
+DEFAULT_CACHE_EXPIRE = (
+    5  # minutes; also caches API responses, kept below the session timeout
+)
 DEFAULT_INSECURE = True
 DEFAULT_NO_PROXY = False
 DEFAULT_RETRIES = 3  # extra attempts on a failed Redfish request

--- a/check-plugins/redfish-systems/redfish-systems
+++ b/check-plugins/redfish-systems/redfish-systems
@@ -32,7 +32,9 @@ indicator LED) and rolled-up health status, and alerts whenever any system's sta
 `OK`. Use `redfish-storage` for drive- and storage-controller-specific monitoring."""
 
 API_BASE = '/redfish/v1'
-DEFAULT_CACHE_EXPIRE = 5  # minutes; also caches API responses, kept below the session timeout
+DEFAULT_CACHE_EXPIRE = (
+    5  # minutes; also caches API responses, kept below the session timeout
+)
 DEFAULT_INSECURE = True
 DEFAULT_NO_PROXY = False
 DEFAULT_RETRIES = 3  # extra attempts on a failed Redfish request

--- a/check-plugins/snmp/unit-test/run
+++ b/check-plugins/snmp/unit-test/run
@@ -36,6 +36,7 @@ def load_plugin_module():
     spec.loader.exec_module(module)
     return module
 
+
 # Absolute path to a device CSV outside the bundled `device-oids` directory,
 # used to exercise the `--device` absolute-path branch. The tests run from the
 # `unit-test` directory, so the fixture resolves relative to the cwd.
@@ -248,14 +249,10 @@ class TestBuildOidChunks(unittest.TestCase):
         chunks = self.plugin.build_oid_chunks(snmp_objects)
         flat = [oid for chunk in chunks for oid in chunk]
         self.assertNotIn('', flat)
-        self.assertEqual(
-            flat, ['IF-MIB::ifInOctets.1', 'IF-MIB::ifOutOctets.1']
-        )
+        self.assertEqual(flat, ['IF-MIB::ifInOctets.1', 'IF-MIB::ifOutOctets.1'])
 
     def test_real_oids_keep_their_order(self):
-        snmp_objects = [self._header()] + [
-            self._row(f'OID::x.{i}') for i in range(5)
-        ]
+        snmp_objects = [self._header()] + [self._row(f'OID::x.{i}') for i in range(5)]
         chunks = self.plugin.build_oid_chunks(snmp_objects)
         flat = [oid for chunk in chunks for oid in chunk]
         self.assertEqual(flat, [f'OID::x.{i}' for i in range(5)])
@@ -446,8 +443,12 @@ class TestMatchOid(unittest.TestCase):
     def test_trailing_space_guard_stops_prefix_collision(self):
         # `...ifName.1` must not swallow the `...ifName.10` line, and each still matches itself
         objs = self._objs('IF-MIB::ifName.1', 'IF-MIB::ifName.10')
-        self.assertEqual(self.plugin.match_oid(objs, 'IF-MIB::ifName.1 lo', 1), (1, 'lo'))
-        self.assertEqual(self.plugin.match_oid(objs, 'IF-MIB::ifName.10 eth0', 1), (2, 'eth0'))
+        self.assertEqual(
+            self.plugin.match_oid(objs, 'IF-MIB::ifName.1 lo', 1), (1, 'lo')
+        )
+        self.assertEqual(
+            self.plugin.match_oid(objs, 'IF-MIB::ifName.10 eth0', 1), (2, 'eth0')
+        )
 
     def test_forward_search_skips_computed_rows(self):
         # a computed row (empty OID) between two real OIDs must be stepped over

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.ruff]
+line-length = 88
 target-version = 'py39'
 
 [tool.ruff.lint]
@@ -30,8 +31,8 @@ ignore = [
 'check-plugins/metabase-stats/metabase-stats' = ['F821', 'B006']
 
 [tool.ruff.format]
-quote-style = 'single'
 docstring-code-format = true
+quote-style = 'single'
 
 [tool.bandit]
 # B110 (try/except/pass) and B112 (try/except/continue): intentional patterns in


### PR DESCRIPTION
The lint configuration grew per repository in April 2026 instead of from a shared template, and firewallfabrik and mcp-server-icinga came from a different project skeleton. That left four dialects behind.

Unified: `line-length` is now stated explicitly as 88 everywhere (the ruff default; checklistfabrik was the outlier at 100), `[tool.ruff.format]` is byte-identical in all six repositories that run ruff, the `select` list is alphabetical, `[tool.bandit.assert_used]` uses one pattern, and strings inside `[tool.*]` are single-quoted. `[build-system]`, `[project]` and `[tool.setuptools]` are left alone: those are per-project and double quotes are the ecosystem norm there.

`target-version`, the `ignore` lists and the extra `PTH`/`TID` rules stay per repository, they follow from the codebase.