### PR TITLE
chore: restore the verbatim Unlicense text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,4 +21,4 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
-For more information, please refer to <http://unlicense.org/>
+For more information, please refer to <https://unlicense.org/>


### PR DESCRIPTION
The closing line of the Unlicense text had drifted into three variants across the repositories:

- `http://unlicense.org/` with no trailing newline
- `https://unlicense.org` without the trailing slash
- a mix of the two

`LICENSE` is tier 1, byte-identical everywhere. The file now matches https://unlicense.org/UNLICENSE exactly. Nothing but that one line changes; `firewallfabrik` is untouched because it is GPL.