### PR TITLE
fix(rpm-versionlock): warn when dnf5 lockfile unreadable on Python <3.11 (#1462)

### DIFF
--- a/check-plugins/rpm-versionlock/rpm-versionlock
+++ b/check-plugins/rpm-versionlock/rpm-versionlock
@@ -565,6 +565,9 @@ def get_dnf5_locks(root):
     DNF5_LOCKFILE_VERSION for the difference and for what was measured.
     """
     if tomllib is None:
+        lockfile = rooted(root, DNF5_LOCKFILE)
+        if lib.disk.file_exists(lockfile, allow_empty=True):
+            return [], [], [f'{lockfile} cannot be read, this needs Python 3.11 or newer']
         return [], [], []
 
     lockfile = rooted(root, DNF5_LOCKFILE)

--- a/check-plugins/rpm-versionlock/unit-test/run
+++ b/check-plugins/rpm-versionlock/unit-test/run
@@ -24,13 +24,11 @@ except ImportError:
 
 # The plugin reads the dnf 5 lock file with `tomllib` and ships no backport, because
 # every distribution that ships dnf 5 also ships a Python that has that module. On the
-# older interpreters of the tox matrix the plugin therefore reports no dnf 5 locks, and
-# the testcases that expect parsed locks cannot pass. They are skipped there instead of
-# asserting the degraded result, so a real regression on those interpreters still fails
-# the run. `ok-dnf5-no-locks` and `warn-excludes-disabled-wholesale-dnf5` stay in,
-# because neither needs the TOML file to be parsed. Drop this skip once the plugin
-# reports the unreadable file instead of staying silent about it, see
-# https://github.com/Linuxfabrik/monitoring-plugins/issues/1462.
+# older interpreters without `tomllib` the plugin reports the unreadable file with
+# WARN ("cannot be read, this needs Python 3.11 or newer") instead of staying silent,
+# so those testcases now assert that message. `ok-dnf5-no-locks` and
+# `warn-excludes-disabled-wholesale-dnf5` stay as they are, because neither needs the
+# TOML file to be parsed, see https://github.com/Linuxfabrik/monitoring-plugins/issues/1462.
 NEEDS_TOMLLIB = [
     'warn-dnf5-broken-toml',
     'warn-dnf5-excludes-checked',
@@ -601,18 +599,15 @@ class TestCheck(unittest.TestCase):
     check = '../rpm-versionlock'
 
 
-lib.lftest.attach_tests(TestCheck, TESTS)
-
 if tomllib is None:
-    for test_id in NEEDS_TOMLLIB:
-        method_name = 'test_' + test_id.replace('-', '_')
-        setattr(
-            TestCheck,
-            method_name,
-            unittest.skip('dnf 5 locks are TOML, which needs Python 3.11 or newer')(
-                getattr(TestCheck, method_name)
-            ),
-        )
+    for testcase in TESTS:
+        if testcase['id'] in NEEDS_TOMLLIB:
+            testcase['assert-retc'] = STATE_WARN
+            testcase['assert-in'] = ['cannot be read, this needs Python 3.11 or newer']
+            testcase.pop('assert-not-in', None)
+            testcase.pop('assert-regex', None)
+
+lib.lftest.attach_tests(TestCheck, TESTS)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1462

`get_dnf5_locks()` returned `[],[],[]` when `tomllib` is unavailable (Python <3.11) even if `/etc/dnf/versionlock.toml` exists, silently reporting OK.

- `check-plugins/rpm-versionlock/rpm-versionlock:568` now checks for the dnf5 lockfile existence when `tomllib is None` and returns `[],[],["<lockfile> cannot be read, this needs Python 3.11 or newer"]` via the `ignored` channel, which `main()` already treats as `STATE_WARN` and displays under "These configurations are read but applied to nothing".
- A host without dnf5 (no lockfile) stays quiet.
- `check-plugins/rpm-versionlock/unit-test/run` removes the `NEEDS_TOMLLIB` skip and makes those 7 testcases assert `WARN` with `cannot be read, this needs Python 3.11 or newer` when `tomllib` is missing, so the same tests pass on both old and new interpreters.

Verified folder-locally: `python ./run` passes (48 tests) on Python 3.14 and simulated `tomllib=None` correctly returns WARN for existing lockfile and OK for missing file.