### PR TITLE
cert: allow for multiple --filename targets

### DIFF
--- a/check-plugins/cert/README.md
+++ b/check-plugins/cert/README.md
@@ -125,7 +125,8 @@ options:
                         one path segment, `**` matches across directories.
                         Always quote the pattern in shells so that the shell
                         does not expand the wildcard before the plugin sees
-                        it. Example: `--filename='/etc/ssl/certs/*.pem'`.
+                        it. Can be specified multiple times. Example:
+                        `--filename='/etc/ssl/certs/*.pem'`.
                         Recursive example:
                         `--filename='/etc/letsencrypt/live/**/cert.pem'`
   -H, --host HOST       Target host to scan. Overrides subnet auto-discovery.

--- a/check-plugins/cert/cert
+++ b/check-plugins/cert/cert
@@ -224,9 +224,11 @@ def parse_args():
         'Python conventions: `*` matches one path segment, `**` matches across '
         'directories. Always quote the pattern in shells so that the shell does not '
         'expand the wildcard before the plugin sees it. '
+        'Can be specified multiple times. '
         "Example: `--filename='/etc/ssl/certs/*.pem'`. "
         "Recursive example: `--filename='/etc/letsencrypt/live/**/cert.pem'`",
         dest='FILENAME',
+        action='append',
     )
 
     parser.add_argument(
@@ -1013,39 +1015,41 @@ def get_certs_from_files(args):
     even when they hit private keys or trust bundles. Files that look like certificates
     but fail to parse are reported as a real error so corrupt certs surface clearly.
     """
-    matches = lib.disk.glob(args.FILENAME)
     items = []
-    matched_files = 0
-    for match in matches:
-        if not lib.disk.file_exists(match, allow_empty=True):
-            continue
-        matched_files += 1
-        success, data = lib.disk.read_file(match, binary=True)
-        if not success:
-            return False, f'Cannot read {match}: {data}'
-        if not _looks_like_cert(data):
-            continue
-        try:
-            cert_ders = _load_all_certs(data)
-        except (ValueError, TypeError) as e:
-            return False, f'Cannot parse certificate from {match}: {e}'
-        for cert_der in cert_ders:
-            items.append(
-                {
-                    'cert_der': cert_der,
-                    'chain_verdict': None,
-                    'handshake_seconds': None,
-                    'label': match,
-                    'proxy': None,
-                    'tls_version': None,
-                }
-            )
+    file_patterns = list(args.FILENAME)
+    for file_pattern in file_patterns:
+        matches = lib.disk.glob(file_pattern)
+        matched_files = 0
+        for match in matches:
+            if not lib.disk.file_exists(match, allow_empty=True):
+                continue
+            matched_files += 1
+            success, data = lib.disk.read_file(match, binary=True)
+            if not success:
+                return False, f'Cannot read {match}: {data}'
+            if not _looks_like_cert(data):
+                continue
+            try:
+                cert_ders = _load_all_certs(data)
+            except (ValueError, TypeError) as e:
+                return False, f'Cannot parse certificate from {match}: {e}'
+            for cert_der in cert_ders:
+                items.append(
+                    {
+                        'cert_der': cert_der,
+                        'chain_verdict': None,
+                        'handshake_seconds': None,
+                        'label': match,
+                        'proxy': None,
+                        'tls_version': None,
+                    }
+                )
     if not items:
         if matched_files == 0:
-            return False, f'No files match "{args.FILENAME}"'
+            return False, f'No files match "{", ".join(args.FILENAME)}"'
         return False, (
             f'No parseable certificates among {matched_files} file(s)'
-            f' matching "{args.FILENAME}"'
+            f' matching "{", ".join(args.FILENAME)}"'
         )
     return True, items
 

--- a/check-plugins/cert/cert
+++ b/check-plugins/cert/cert
@@ -1016,10 +1016,10 @@ def get_certs_from_files(args):
     but fail to parse are reported as a real error so corrupt certs surface clearly.
     """
     items = []
+    matched_files = 0
     file_patterns = list(args.FILENAME)
     for file_pattern in file_patterns:
         matches = lib.disk.glob(file_pattern)
-        matched_files = 0
         for match in matches:
             if not lib.disk.file_exists(match, allow_empty=True):
                 continue

--- a/check-plugins/cert/icingaweb2-module-director/cert.json
+++ b/check-plugins/cert/icingaweb2-module-director/cert.json
@@ -23,7 +23,8 @@
                     "repeat_key": true
                 },
                 "--filename": {
-                    "value": "$cert_filename$"
+                    "value": "$cert_filename$",
+                    "repeat_key": true
                 },
                 "--host": {
                     "value": "$cert_host$",

--- a/check-plugins/cert/unit-test/run
+++ b/check-plugins/cert/unit-test/run
@@ -796,6 +796,17 @@ class TestFileSource(unittest.TestCase):
         self.assertEqual(result.returncode, STATE_OK, result.stdout)
         self.assertIn('test.example.com', result.stdout)
 
+    def test_ok_two_file(self):
+        cert_pem1, _ = make_cert('test1.example.com', days_valid=60)
+        path1 = self._write(cert_pem1)
+        cert_pem2, _ = make_cert('test2.example.com', days_valid=60)
+        path2 = self._write(cert_pem2)
+        result = run_plugin('--source', 'file', '--filename', path1, '--filename', path2)
+        self.assertEqual(result.returncode, STATE_OK, result.stdout)
+        self.assertIn('test1.example.com', result.stdout)
+        self.assertIn('test2.example.com', result.stdout)
+        self.assertIn('59d left', result.stdout)
+
     def test_crit_expired_file(self):
         cert_pem, _ = make_cert(
             'test.example.com',


### PR DESCRIPTION
This feature allows to specify the `--filename` argument multiple times.

This allows to check certificates in different files with very different path.

